### PR TITLE
Ensure access modifiers are serialized

### DIFF
--- a/packages/core/src/serializers/signature.ts
+++ b/packages/core/src/serializers/signature.ts
@@ -37,7 +37,7 @@ export default function serializeSignature(
   if (parameters && parameters.length > 0) {
     out.parameters = parameters.map(p => q.queue(p, 'symbol')).filter(isRef);
   }
-  out.typeString = checker.signatureToString(signature);
+  out.text = checker.signatureToString(signature);
   // tslint:disable-next-line:no-commented-code
   // visitType(getRestTypeOfSignature(signature));
   // TODO: ...rest type signature??

--- a/packages/core/src/serializers/symbol.ts
+++ b/packages/core/src/serializers/symbol.ts
@@ -62,15 +62,7 @@ function serializeSymbolDeclarationData(
   }
   const { queue: q } = c;
   const serialized: Pick<SerializedSymbol, SYMBOL_DECLARATION_PROPS> = {};
-  const { modifiers, decorators } = decl;
-  if (modifiers) {
-    serialized.modifiers = modifiersToStrings(modifiers);
-  }
-  if (decorators) {
-    serialized.decorators = decorators
-      .map(d => q.queue(checker.getSymbolAtLocation(d.expression), 'symbol'))
-      .filter(isDefined);
-  }
+
   if (symbol.getJsDocTags().length > 0 || symbol.getDocumentationComment(checker).length > 0) {
     const txt = extractDocumentationText(decl);
     serialized.jsDocTags = symbol.getJsDocTags().map(t => ({ name: t.name, text: t.text }));
@@ -180,6 +172,17 @@ export default function serializeSymbol(
   const decl = relevantDeclarationForSymbol(symbol);
   if (decl && isAbstractDeclaration(decl)) {
     serialized.isAbstract = true;
+  }
+  if (decl) {
+    const { modifiers, decorators } = decl;
+    if (modifiers) {
+      serialized.modifiers = modifiersToStrings(modifiers);
+    }
+    if (decorators) {
+      serialized.decorators = decorators
+        .map(d => q.queue(checker.getSymbolAtLocation(d.expression), 'symbol'))
+        .filter(isDefined);
+    }
   }
   if (!c.cfg.shouldSerializeSymbolDetails(checker, symbol, type, decl)) {
     return serialized;

--- a/packages/core/src/serializers/symbol.ts
+++ b/packages/core/src/serializers/symbol.ts
@@ -177,7 +177,7 @@ export default function serializeSymbol(
     id,
     entity: 'symbol',
     name,
-    symbolString: checker.symbolToString(symbol),
+    text: checker.symbolToString(symbol),
     flags: flagsToString(flags, 'symbol') || [],
     type: q.queue(type, 'type'),
     ...handleRelatedEntities(symbol, ref, relatedEntities, q),

--- a/packages/core/src/serializers/symbol.ts
+++ b/packages/core/src/serializers/symbol.ts
@@ -127,6 +127,23 @@ function handleRelatedEntities(
   return { relatedSymbols };
 }
 
+function serializeTypeAndSymbolStrings(
+  symbol: ts.Symbol,
+  type: ts.Type | undefined,
+  checker: ts.TypeChecker,
+): Pick<SerializedSymbol, 'symbolString' | 'typeString'> | undefined {
+  const symbolString = checker.symbolToString(symbol);
+  const typeString = type ? checker.typeToString(type) : undefined;
+  const out: Pick<SerializedSymbol, 'symbolString' | 'typeString'> = {};
+  if (symbolString) {
+    out.symbolString = symbolString;
+  }
+  if (typeString) {
+    out.typeString = typeString;
+  }
+  return out;
+}
+
 /**
  * Serialize a ts.Symbol to JSON
  *
@@ -158,16 +175,11 @@ export default function serializeSymbol(
     type: q.queue(type, 'type'),
     ...handleRelatedEntities(symbol, ref, relatedEntities, q),
   };
-  const symbolString = checker.symbolToString(symbol);
-  const typeString = type ? checker.typeToString(type) : undefined;
-  if (symbolString) {
-    serialized.symbolString = symbolString;
-  }
-  if (typeString) {
-    serialized.typeString = typeString;
-  }
-
-  Object.assign(serialized, serializeExportedSymbols(exportedSymbols, q));
+  Object.assign(
+    serialized,
+    serializeExportedSymbols(exportedSymbols, q),
+    serializeTypeAndSymbolStrings(symbol, type, checker),
+  );
 
   const decl = relevantDeclarationForSymbol(symbol);
   if (decl && isAbstractDeclaration(decl)) {

--- a/packages/core/src/serializers/type.ts
+++ b/packages/core/src/serializers/type.ts
@@ -277,7 +277,7 @@ export default function serializeType(
 ): SerializedType {
   const { symbol, isThisType } = type as { symbol?: ts.Symbol; isThisType?: boolean };
   const serialized: SerializedType = {
-    typeString: checker.typeToString(type),
+    text: checker.typeToString(type),
     entity: 'type',
     id: refId(ref),
     flags: flagsToString(type.flags, 'type') || [],

--- a/packages/core/src/types/serialized-entities.ts
+++ b/packages/core/src/types/serialized-entities.ts
@@ -35,7 +35,7 @@ export interface SerializedSymbol
   decorators?: SymbolRef[];
   modifiers?: string[];
   globalExports?: Dict<SymbolRef>;
-  symbolString: string;
+  text: string;
   heritageClauses?: SerializedHeritageClause[];
   relatedSymbols?: SymbolRef[];
   isAbstract?: boolean;
@@ -57,7 +57,7 @@ export interface SerializedSignature {
   modifiers?: string[];
   returnType?: TypeRef;
   comment?: string;
-  typeString?: string;
+  text?: string;
 }
 
 /**
@@ -155,7 +155,7 @@ export interface SerializedType extends SerializedEntity<'type'>, HasDocumentati
   objectType?: TypeRef;
   properties?: Dict<SymbolRef>;
   isThisType?: boolean;
-  typeString: string;
+  text: string;
   primitive?: boolean;
   objectFlags?: Flags;
   numberIndexType?: TypeRef;

--- a/packages/core/src/types/serialized-entities.ts
+++ b/packages/core/src/types/serialized-entities.ts
@@ -35,8 +35,7 @@ export interface SerializedSymbol
   decorators?: SymbolRef[];
   modifiers?: string[];
   globalExports?: Dict<SymbolRef>;
-  typeString?: string;
-  symbolString?: string;
+  symbolString: string;
   heritageClauses?: SerializedHeritageClause[];
   relatedSymbols?: SymbolRef[];
   isAbstract?: boolean;

--- a/packages/core/test/acceptance/array.test.ts
+++ b/packages/core/test/acceptance/array.test.ts
@@ -13,14 +13,14 @@ export class ArraySerializationTests {
     const file = t.sourceFile();
     const fileSymbol = t.resolveReference(file.symbol);
     const variableSymbol = t.resolveReference(fileSymbol.exports!.x);
-    expect(variableSymbol.symbolString).to.eql('x');
+    expect(variableSymbol.text).to.eql('x');
     expect(variableSymbol.flags).to.eql(['BlockScopedVariable'], 'Regarded as a variable');
 
     const variableType = t.resolveReference(variableSymbol.type);
-    expect(variableType.typeString).to.eql('string[]');
+    expect(variableType.text).to.eql('string[]');
     expect(variableType.flags).to.deep.eq(['Object']);
     const arrayType = t.resolveReference(variableType.numberIndexType);
-    expect(arrayType.typeString).to.eq('string');
+    expect(arrayType.text).to.eq('string');
     t.cleanup();
   }
 
@@ -32,14 +32,14 @@ export class ArraySerializationTests {
     const file = t.sourceFile();
     const fileSymbol = t.resolveReference(file.symbol);
     const variableSymbol = t.resolveReference(fileSymbol.exports!.x);
-    expect(variableSymbol.symbolString).to.eql('x');
+    expect(variableSymbol.text).to.eql('x');
     expect(variableSymbol.flags).to.eql(['BlockScopedVariable'], 'Regarded as a variable');
 
     const variableType = t.resolveReference(variableSymbol.type);
-    expect(variableType.typeString).to.eql('[string, number, number]');
+    expect(variableType.text).to.eql('[string, number, number]');
     expect(variableType.flags).to.deep.eq(['Object']);
     const arrayType = t.resolveReference(variableType.numberIndexType);
-    expect(arrayType.typeString).to.eq('string | number');
+    expect(arrayType.text).to.eq('string | number');
     t.cleanup();
   }
 }

--- a/packages/core/test/acceptance/array.test.ts
+++ b/packages/core/test/acceptance/array.test.ts
@@ -14,7 +14,6 @@ export class ArraySerializationTests {
     const fileSymbol = t.resolveReference(file.symbol);
     const variableSymbol = t.resolveReference(fileSymbol.exports!.x);
     expect(variableSymbol.symbolString).to.eql('x');
-    expect(variableSymbol.typeString).to.eql('string[]', 'has correct type');
     expect(variableSymbol.flags).to.eql(['BlockScopedVariable'], 'Regarded as a variable');
 
     const variableType = t.resolveReference(variableSymbol.type);
@@ -34,7 +33,6 @@ export class ArraySerializationTests {
     const fileSymbol = t.resolveReference(file.symbol);
     const variableSymbol = t.resolveReference(fileSymbol.exports!.x);
     expect(variableSymbol.symbolString).to.eql('x');
-    expect(variableSymbol.typeString).to.eql('[string, number, number]', 'has correct type');
     expect(variableSymbol.flags).to.eql(['BlockScopedVariable'], 'Regarded as a variable');
 
     const variableType = t.resolveReference(variableSymbol.type);

--- a/packages/core/test/acceptance/class.test.ts
+++ b/packages/core/test/acceptance/class.test.ts
@@ -248,6 +248,8 @@ export class Car extends Vehicle {}`;
   protected static hello(): string { return 'world'; }
 
   protected readonly foo: string = 'bar';
+  public myBar: string = 'bar';
+  private myBaz: string[] = ['baz'];
 
   private constructor(bar: string) { console.log(bar); }
 }`;
@@ -279,9 +281,9 @@ export class Car extends Vehicle {}`;
     const instanceType = t.resolveReference(constructorSig.returnType);
     expect(instanceType.typeString).to.eq('SimpleClass');
     const instancePropNames = Object.keys(instanceType.properties!);
-    expect(instancePropNames).to.deep.eq(['foo']);
+    expect(instancePropNames).to.deep.eq(['foo', 'myBar', 'myBaz']);
     const props = instancePropNames.map(p => t.resolveReference(instanceType.properties![p]));
-    const [fooSym] = props;
+    const [fooSym, myBarSym, myBazSym] = props;
     expect(fooSym.flags).to.deep.eq(['Property']);
     expect(fooSym.symbolString).to.eq('foo');
     const [fooType] = props.map(s => t.resolveReference(s.type));
@@ -289,6 +291,8 @@ export class Car extends Vehicle {}`;
     expect(fooType.typeString).to.eql('string');
     expect(fooType.flags).to.deep.eq(['String']);
 
+    expect(myBarSym.modifiers).to.deep.eq(['public']);
+    expect(myBazSym.modifiers).to.deep.eq(['private']);
     t.cleanup();
   }
 }

--- a/packages/core/test/acceptance/class.test.ts
+++ b/packages/core/test/acceptance/class.test.ts
@@ -16,7 +16,6 @@ export class ClassSerializationTests {
     const fileSymbol = t.resolveReference(file.symbol);
     const classSymbol = t.resolveReference(fileSymbol.exports!.Vehicle);
     expect(classSymbol.symbolString).to.eql('Vehicle');
-    expect(classSymbol.typeString).to.eql('typeof Vehicle', 'has correct type');
     expect(classSymbol.flags).to.eql(['Class'], 'Regarded as a class');
     expect(classSymbol.modifiers).to.include('export');
 
@@ -62,7 +61,6 @@ export class ClassSerializationTests {
     const fileSymbol = t.resolveReference(file.symbol);
     const classSymbol = t.resolveReference(fileSymbol.exports!.Vehicle);
     expect(classSymbol.symbolString).to.eql('Vehicle');
-    expect(classSymbol.typeString).to.eql('typeof Vehicle', 'has correct type');
     expect(classSymbol.flags).to.eql(['Class'], 'Regarded as a class');
     expect(classSymbol.modifiers).to.include('export');
     expect(classSymbol.isAbstract).to.eql(true);
@@ -106,7 +104,6 @@ export class ClassSerializationTests {
     const fileSymbol = t.resolveReference(file.symbol);
     const classSymbol = t.resolveReference(fileSymbol.exports!.Vehicle);
     expect(classSymbol.symbolString).to.eql('Vehicle');
-    expect(classSymbol.typeString).to.eql('typeof Vehicle', 'has correct type');
     expect(classSymbol.flags).to.eql(['Class'], 'Regarded as a class');
     expect(classSymbol.modifiers).to.include('export');
 
@@ -136,7 +133,6 @@ export class Car extends Vehicle {}`;
     const fileSymbol = t.resolveReference(file.symbol);
     const classSymbol = t.resolveReference(fileSymbol.exports!.Car);
     expect(classSymbol.symbolString).to.eql('Car');
-    expect(classSymbol.typeString).to.eql('typeof Car', 'has correct type');
     expect(classSymbol.flags).to.eql(['Class'], 'Regarded as a class');
     expect(classSymbol.modifiers).to.include('export');
 
@@ -168,7 +164,6 @@ export class Car extends Vehicle {}`;
     const fileSymbol = t.resolveReference(file.symbol);
     const classSymbol = t.resolveReference(fileSymbol.exports!.Car);
     expect(classSymbol.symbolString).to.eql('Car');
-    expect(classSymbol.typeString).to.eql('typeof Car', 'has correct type');
     expect(classSymbol.flags).to.eql(['Class'], 'Regarded as a class');
     expect(classSymbol.modifiers).to.include('export');
 
@@ -200,7 +195,6 @@ export class Car extends Vehicle {}`;
     const fileSymbol = t.resolveReference(file.symbol);
     const classSymbol = t.resolveReference(fileSymbol.exports!.SimpleClass);
     expect(classSymbol.symbolString).to.eql('SimpleClass');
-    expect(classSymbol.typeString).to.eql('typeof SimpleClass', 'has correct type');
     expect(classSymbol.flags).to.eql(['Class'], 'Regarded as a class');
     expect(classSymbol.modifiers).to.include('export');
 
@@ -259,7 +253,6 @@ export class Car extends Vehicle {}`;
     const fileSymbol = t.resolveReference(file.symbol);
     const classSymbol = t.resolveReference(fileSymbol.exports!.SimpleClass);
     expect(classSymbol.symbolString).to.eql('SimpleClass');
-    expect(classSymbol.typeString).to.eql('typeof SimpleClass', 'has correct type');
     expect(classSymbol.flags).to.eql(['Class'], 'Regarded as a class');
     expect(classSymbol.modifiers).to.include('export');
 

--- a/packages/core/test/acceptance/class.test.ts
+++ b/packages/core/test/acceptance/class.test.ts
@@ -15,33 +15,33 @@ export class ClassSerializationTests {
     const file = t.sourceFile();
     const fileSymbol = t.resolveReference(file.symbol);
     const classSymbol = t.resolveReference(fileSymbol.exports!.Vehicle);
-    expect(classSymbol.symbolString).to.eql('Vehicle');
+    expect(classSymbol.text).to.eql('Vehicle');
     expect(classSymbol.flags).to.eql(['Class'], 'Regarded as a class');
     expect(classSymbol.modifiers).to.include('export');
 
     const classType = t.resolveReference(classSymbol.type);
-    expect(classType.typeString).to.eql('typeof Vehicle');
+    expect(classType.text).to.eql('typeof Vehicle');
     expect(classType.flags).to.deep.eq(['Object']);
     expect(classType.constructorSignatures!.length).to.eq(1, '1 constructor signature');
 
     const classPropNames = Object.keys(classType.properties!);
     expect(classPropNames).to.deep.eq([]);
     const [constructorSig] = classType.constructorSignatures!;
-    expect(constructorSig.typeString).to.eq('(): Vehicle');
+    expect(constructorSig.text).to.eq('(): Vehicle');
     const instanceType = t.resolveReference(constructorSig.returnType);
-    expect(instanceType.typeString).to.eq('Vehicle');
+    expect(instanceType.text).to.eq('Vehicle');
     const instancePropNames = Object.keys(instanceType.properties!);
     expect(instancePropNames).to.deep.eq(['numWheels', 'drive']);
     const props = instancePropNames.map(p => t.resolveReference(instanceType.properties![p]));
     const [numWheelsSym, driveSym] = props;
     expect(numWheelsSym.flags).to.deep.eq(['Property']);
     expect(driveSym.flags).to.deep.eq(['Method', 'Transient']);
-    expect(numWheelsSym.symbolString).to.eq('numWheels');
-    expect(driveSym.symbolString).to.eq('drive');
+    expect(numWheelsSym.text).to.eq('numWheels');
+    expect(driveSym.text).to.eq('drive');
     const [numWheelsType, driveType] = props.map(s => t.resolveReference(s.type));
 
-    expect(numWheelsType.typeString).to.eql('number');
-    expect(driveType.typeString).to.eql('() => string');
+    expect(numWheelsType.text).to.eql('number');
+    expect(driveType.text).to.eql('() => string');
     expect(numWheelsType.flags).to.deep.eq(['Number']);
     expect(driveType.flags).to.deep.eq(['Object']);
     expect(driveType.objectFlags).to.includes('Anonymous');
@@ -60,35 +60,35 @@ export class ClassSerializationTests {
     const file = t.sourceFile();
     const fileSymbol = t.resolveReference(file.symbol);
     const classSymbol = t.resolveReference(fileSymbol.exports!.Vehicle);
-    expect(classSymbol.symbolString).to.eql('Vehicle');
+    expect(classSymbol.text).to.eql('Vehicle');
     expect(classSymbol.flags).to.eql(['Class'], 'Regarded as a class');
     expect(classSymbol.modifiers).to.include('export');
     expect(classSymbol.isAbstract).to.eql(true);
 
     const classType = t.resolveReference(classSymbol.type);
-    expect(classType.typeString).to.eql('typeof Vehicle');
+    expect(classType.text).to.eql('typeof Vehicle');
     expect(classType.flags).to.deep.eq(['Object']);
     expect(classType.constructorSignatures!.length).to.eq(1, '1 constructor signature');
 
     const classPropNames = Object.keys(classType.properties!);
     expect(classPropNames).to.deep.eq([]);
     const [constructorSig] = classType.constructorSignatures!;
-    expect(constructorSig.typeString).to.eq('(): Vehicle');
+    expect(constructorSig.text).to.eq('(): Vehicle');
     const instanceType = t.resolveReference(constructorSig.returnType);
-    expect(instanceType.typeString).to.eq('Vehicle');
+    expect(instanceType.text).to.eq('Vehicle');
     const instancePropNames = Object.keys(instanceType.properties!);
     expect(instancePropNames).to.deep.eq(['numWheels', 'drive']);
     const props = instancePropNames.map(p => t.resolveReference(instanceType.properties![p]));
     const [numWheelsSym, driveSym] = props;
     expect(numWheelsSym.flags).to.deep.eq(['Property']);
     expect(driveSym.flags).to.deep.eq(['Method']);
-    expect(numWheelsSym.symbolString).to.eq('numWheels');
-    expect(driveSym.symbolString).to.eq('drive');
+    expect(numWheelsSym.text).to.eq('numWheels');
+    expect(driveSym.text).to.eq('drive');
     expect(driveSym.isAbstract).to.eq(true);
     const [numWheelsType, driveType] = props.map(s => t.resolveReference(s.type));
 
-    expect(numWheelsType.typeString).to.eql('number');
-    expect(driveType.typeString).to.eql('() => string');
+    expect(numWheelsType.text).to.eql('number');
+    expect(driveType.text).to.eql('() => string');
     expect(numWheelsType.flags).to.deep.eq(['Number']);
     expect(driveType.flags).to.deep.eq(['Object']);
     expect(driveType.objectFlags).to.includes('Anonymous');
@@ -103,19 +103,19 @@ export class ClassSerializationTests {
     const file = t.sourceFile();
     const fileSymbol = t.resolveReference(file.symbol);
     const classSymbol = t.resolveReference(fileSymbol.exports!.Vehicle);
-    expect(classSymbol.symbolString).to.eql('Vehicle');
+    expect(classSymbol.text).to.eql('Vehicle');
     expect(classSymbol.flags).to.eql(['Class'], 'Regarded as a class');
     expect(classSymbol.modifiers).to.include('export');
 
     const classType = t.resolveReference(classSymbol.type);
-    expect(classType.typeString).to.eql('typeof Vehicle');
+    expect(classType.text).to.eql('typeof Vehicle');
     expect(classType.flags).to.deep.eq(['Object']);
     expect(classType.constructorSignatures!.length).to.eq(1, '1 constructor signature');
 
     const classPropNames = Object.keys(classType.properties!);
     expect(classPropNames).to.deep.eq([]);
     const [constructorSig] = classType.constructorSignatures!;
-    expect(constructorSig.typeString).to.eq('(): Vehicle');
+    expect(constructorSig.text).to.eq('(): Vehicle');
 
     t.cleanup();
   }
@@ -132,19 +132,19 @@ export class Car extends Vehicle {}`;
     const file = t.sourceFile();
     const fileSymbol = t.resolveReference(file.symbol);
     const classSymbol = t.resolveReference(fileSymbol.exports!.Car);
-    expect(classSymbol.symbolString).to.eql('Car');
+    expect(classSymbol.text).to.eql('Car');
     expect(classSymbol.flags).to.eql(['Class'], 'Regarded as a class');
     expect(classSymbol.modifiers).to.include('export');
 
     const classType = t.resolveReference(classSymbol.type);
-    expect(classType.typeString).to.eql('typeof Car');
+    expect(classType.text).to.eql('typeof Car');
     expect(classType.flags).to.deep.eq(['Object']);
     expect(classType.constructorSignatures!.length).to.eq(1, '1 constructor signature');
 
     const classPropNames = Object.keys(classType.properties!);
     expect(classPropNames).to.deep.eq([]);
     const [constructorSig] = classType.constructorSignatures!;
-    expect(constructorSig.typeString).to.eq('(n: number): Car');
+    expect(constructorSig.text).to.eq('(n: number): Car');
 
     t.cleanup();
   }
@@ -163,20 +163,20 @@ export class Car extends Vehicle {}`;
     const file = t.sourceFile();
     const fileSymbol = t.resolveReference(file.symbol);
     const classSymbol = t.resolveReference(fileSymbol.exports!.Car);
-    expect(classSymbol.symbolString).to.eql('Car');
+    expect(classSymbol.text).to.eql('Car');
     expect(classSymbol.flags).to.eql(['Class'], 'Regarded as a class');
     expect(classSymbol.modifiers).to.include('export');
 
     const classType = t.resolveReference(classSymbol.type);
-    expect(classType.typeString).to.eql('typeof Car');
+    expect(classType.text).to.eql('typeof Car');
     expect(classType.flags).to.deep.eq(['Object']);
     expect(classType.constructorSignatures!.length).to.eq(2, '2 constructor signatures');
 
     const classPropNames = Object.keys(classType.properties!);
     expect(classPropNames).to.deep.eq([]);
     const [constructorSig1, constructorSig2] = classType.constructorSignatures!;
-    expect(constructorSig1.typeString).to.eq('(n: number): Car');
-    expect(constructorSig2.typeString).to.eq('(n: number, coeff: number): Car');
+    expect(constructorSig1.text).to.eq('(n: number): Car');
+    expect(constructorSig2.text).to.eq('(n: number, coeff: number): Car');
 
     t.cleanup();
   }
@@ -194,12 +194,12 @@ export class Car extends Vehicle {}`;
     const file = t.sourceFile();
     const fileSymbol = t.resolveReference(file.symbol);
     const classSymbol = t.resolveReference(fileSymbol.exports!.SimpleClass);
-    expect(classSymbol.symbolString).to.eql('SimpleClass');
+    expect(classSymbol.text).to.eql('SimpleClass');
     expect(classSymbol.flags).to.eql(['Class'], 'Regarded as a class');
     expect(classSymbol.modifiers).to.include('export');
 
     const classType = t.resolveReference(classSymbol.type);
-    expect(classType.typeString).to.eql('typeof SimpleClass');
+    expect(classType.text).to.eql('typeof SimpleClass');
     expect(classType.flags).to.deep.eq(['Object']);
     expect(classType.constructorSignatures!.length).to.eq(1, '1 constructor signature');
 
@@ -208,26 +208,26 @@ export class Car extends Vehicle {}`;
     const [helloSym, planetSym] = classPropNames.map(n =>
       t.resolveReference(classType.properties![n]),
     );
-    expect(helloSym.symbolString).to.eq('hello');
+    expect(helloSym.text).to.eq('hello');
     expect(helloSym.modifiers).to.deep.eq(['static']);
     expect(helloSym.flags).to.deep.eq(['Method']);
-    expect(planetSym.symbolString).to.eq('planet');
+    expect(planetSym.text).to.eq('planet');
     expect(planetSym.modifiers).to.deep.eq(['static']);
     expect(planetSym.flags).to.deep.eq(['Property']);
 
     const [constructorSig] = classType.constructorSignatures!;
-    expect(constructorSig.typeString).to.eq('(bar: string): SimpleClass');
+    expect(constructorSig.text).to.eq('(bar: string): SimpleClass');
     const instanceType = t.resolveReference(constructorSig.returnType);
-    expect(instanceType.typeString).to.eq('SimpleClass');
+    expect(instanceType.text).to.eq('SimpleClass');
     const instancePropNames = Object.keys(instanceType.properties!);
     expect(instancePropNames).to.deep.eq(['foo']);
     const props = instancePropNames.map(p => t.resolveReference(instanceType.properties![p]));
     const [fooSym] = props;
     expect(fooSym.flags).to.deep.eq(['Property']);
-    expect(fooSym.symbolString).to.eq('foo');
+    expect(fooSym.text).to.eq('foo');
     const [fooType] = props.map(s => t.resolveReference(s.type));
 
-    expect(fooType.typeString).to.eql('string');
+    expect(fooType.text).to.eql('string');
     expect(fooType.flags).to.deep.eq(['String']);
 
     t.cleanup();
@@ -252,36 +252,36 @@ export class Car extends Vehicle {}`;
     const file = t.sourceFile();
     const fileSymbol = t.resolveReference(file.symbol);
     const classSymbol = t.resolveReference(fileSymbol.exports!.SimpleClass);
-    expect(classSymbol.symbolString).to.eql('SimpleClass');
+    expect(classSymbol.text).to.eql('SimpleClass');
     expect(classSymbol.flags).to.eql(['Class'], 'Regarded as a class');
     expect(classSymbol.modifiers).to.include('export');
 
     const classType = t.resolveReference(classSymbol.type);
-    expect(classType.typeString).to.eql('typeof SimpleClass');
+    expect(classType.text).to.eql('typeof SimpleClass');
     expect(classType.flags).to.deep.eq(['Object']);
     expect(classType.constructorSignatures!.length).to.eq(1, '1 constructor signature');
 
     const classPropNames = Object.keys(classType.properties!);
     expect(classPropNames).to.deep.eq(['hello']);
     const [helloSym] = classPropNames.map(n => t.resolveReference(classType.properties![n]));
-    expect(helloSym.symbolString).to.eq('hello');
+    expect(helloSym.text).to.eq('hello');
     expect(helloSym.modifiers).to.include('protected', 'static');
     expect(helloSym.flags).to.deep.eq(['Method']);
 
     const [constructorSig] = classType.constructorSignatures!;
-    expect(constructorSig.typeString).to.eq('(bar: string): SimpleClass');
+    expect(constructorSig.text).to.eq('(bar: string): SimpleClass');
     expect(constructorSig.modifiers).to.deep.eq(['private']);
     const instanceType = t.resolveReference(constructorSig.returnType);
-    expect(instanceType.typeString).to.eq('SimpleClass');
+    expect(instanceType.text).to.eq('SimpleClass');
     const instancePropNames = Object.keys(instanceType.properties!);
     expect(instancePropNames).to.deep.eq(['foo', 'myBar', 'myBaz']);
     const props = instancePropNames.map(p => t.resolveReference(instanceType.properties![p]));
     const [fooSym, myBarSym, myBazSym] = props;
     expect(fooSym.flags).to.deep.eq(['Property']);
-    expect(fooSym.symbolString).to.eq('foo');
+    expect(fooSym.text).to.eq('foo');
     const [fooType] = props.map(s => t.resolveReference(s.type));
 
-    expect(fooType.typeString).to.eql('string');
+    expect(fooType.text).to.eql('string');
     expect(fooType.flags).to.deep.eq(['String']);
 
     expect(myBarSym.modifiers).to.deep.eq(['public']);

--- a/packages/core/test/acceptance/comment.test.ts
+++ b/packages/core/test/acceptance/comment.test.ts
@@ -18,14 +18,14 @@ export class CommentSerializationTests {
     const file = t.sourceFile();
     const fileSymbol = t.resolveReference(file.symbol);
     const variableSymbol = t.resolveReference(fileSymbol.exports!.x);
-    expect(variableSymbol.symbolString).to.eql('x');
+    expect(variableSymbol.text).to.eql('x');
     expect(variableSymbol.flags).to.eql(['BlockScopedVariable'], 'Regarded as a variable');
 
     expect(variableSymbol.documentation).to.deep.eq({
       summary: ['A thing'],
     });
     const variableType = t.resolveReference(variableSymbol.type);
-    expect(variableType.typeString).to.eql('Foo', 'has correct type');
+    expect(variableType.text).to.eql('Foo', 'has correct type');
 
     t.cleanup();
   }
@@ -44,7 +44,7 @@ export class CommentSerializationTests {
     const file = t.sourceFile();
     const fileSymbol = t.resolveReference(file.symbol);
     const variableSymbol = t.resolveReference(fileSymbol.exports!.x);
-    expect(variableSymbol.symbolString).to.eql('x');
+    expect(variableSymbol.text).to.eql('x');
     expect(variableSymbol.flags).to.eql(['BlockScopedVariable'], 'Regarded as a variable');
 
     expect(variableSymbol.documentation).to.deep.eq({
@@ -59,7 +59,7 @@ export class CommentSerializationTests {
     });
 
     const variableType = t.resolveReference(variableSymbol.type);
-    expect(variableType.typeString).to.eql('Foo', 'has correct type');
+    expect(variableType.text).to.eql('Foo', 'has correct type');
 
     t.cleanup();
   }
@@ -79,7 +79,7 @@ export class CommentSerializationTests {
     const file = t.sourceFile();
     const fileSymbol = t.resolveReference(file.symbol);
     const functionSymbol = t.resolveReference(fileSymbol.exports!.add);
-    expect(functionSymbol.symbolString).to.eql('add');
+    expect(functionSymbol.text).to.eql('add');
     expect(functionSymbol.flags).to.eql(['Function'], 'Regarded as a function');
 
     expect(functionSymbol.documentation).to.deep.eq({
@@ -101,7 +101,7 @@ export class CommentSerializationTests {
     });
 
     const functionType = t.resolveReference(functionSymbol.type);
-    expect(functionType.typeString).to.eql('(a: number, b: number) => number');
+    expect(functionType.text).to.eql('(a: number, b: number) => number');
     const [callSig1] = functionType.callSignatures!;
     expect(callSig1.parameters!.length).to.eql(2);
     const [sig1Param1, sig1Param2] = callSig1.parameters!.map(p => t.resolveReference(p));

--- a/packages/core/test/acceptance/comment.test.ts
+++ b/packages/core/test/acceptance/comment.test.ts
@@ -19,12 +19,14 @@ export class CommentSerializationTests {
     const fileSymbol = t.resolveReference(file.symbol);
     const variableSymbol = t.resolveReference(fileSymbol.exports!.x);
     expect(variableSymbol.symbolString).to.eql('x');
-    expect(variableSymbol.typeString).to.eql('Foo', 'has correct type');
     expect(variableSymbol.flags).to.eql(['BlockScopedVariable'], 'Regarded as a variable');
 
     expect(variableSymbol.documentation).to.deep.eq({
       summary: ['A thing'],
     });
+    const variableType = t.resolveReference(variableSymbol.type);
+    expect(variableType.typeString).to.eql('Foo', 'has correct type');
+
     t.cleanup();
   }
 
@@ -43,7 +45,6 @@ export class CommentSerializationTests {
     const fileSymbol = t.resolveReference(file.symbol);
     const variableSymbol = t.resolveReference(fileSymbol.exports!.x);
     expect(variableSymbol.symbolString).to.eql('x');
-    expect(variableSymbol.typeString).to.eql('Foo', 'has correct type');
     expect(variableSymbol.flags).to.eql(['BlockScopedVariable'], 'Regarded as a variable');
 
     expect(variableSymbol.documentation).to.deep.eq({
@@ -56,6 +57,10 @@ export class CommentSerializationTests {
         },
       ],
     });
+
+    const variableType = t.resolveReference(variableSymbol.type);
+    expect(variableType.typeString).to.eql('Foo', 'has correct type');
+
     t.cleanup();
   }
 
@@ -75,10 +80,6 @@ export class CommentSerializationTests {
     const fileSymbol = t.resolveReference(file.symbol);
     const functionSymbol = t.resolveReference(fileSymbol.exports!.add);
     expect(functionSymbol.symbolString).to.eql('add');
-    expect(functionSymbol.typeString).to.eql(
-      '(a: number, b: number) => number',
-      'has correct type',
-    );
     expect(functionSymbol.flags).to.eql(['Function'], 'Regarded as a function');
 
     expect(functionSymbol.documentation).to.deep.eq({
@@ -108,6 +109,7 @@ export class CommentSerializationTests {
     expect(sig1Param2.jsDocTags![0].name).to.eq('param');
     expect(sig1Param1.jsDocTags![0].text).contains('first number');
     expect(sig1Param2.jsDocTags![0].text).contains('second number');
+
     t.cleanup();
   }
 

--- a/packages/core/test/acceptance/functions.test.ts
+++ b/packages/core/test/acceptance/functions.test.ts
@@ -13,21 +13,21 @@ export class FunctionAnalysisTests {
     const file = t.sourceFile();
     const fileSymbol = t.resolveReference(file.symbol);
     const functionSymbol = t.resolveReference(fileSymbol.exports!.foo);
-    expect(functionSymbol.symbolString).to.eql('foo');
+    expect(functionSymbol.text).to.eql('foo');
     expect(functionSymbol.flags).to.eql(['Function'], 'Regarded as a function');
 
     const functionType = t.resolveReference(functionSymbol.type);
-    expect(functionType.typeString).to.eql('() => string');
+    expect(functionType.text).to.eql('() => string');
     expect(functionType.flags).to.deep.eq(['Object']);
-    expect(functionType.typeString).to.eql('() => string', 'has correct type');
+    expect(functionType.text).to.eql('() => string', 'has correct type');
 
     expect(functionType.callSignatures!.length).to.eql(1);
     const [callSig] = functionType.callSignatures!;
-    expect(callSig.typeString).to.eql('(): string');
+    expect(callSig.text).to.eql('(): string');
     expect(callSig.parameters).to.eql(undefined);
     expect(callSig.hasRestParameter).to.eql(false);
     const returnType = t.resolveReference(callSig.returnType!);
-    expect(returnType.typeString).to.eq('string');
+    expect(returnType.text).to.eq('string');
 
     t.cleanup();
   }
@@ -40,24 +40,24 @@ export class FunctionAnalysisTests {
     const file = t.sourceFile();
     const fileSymbol = t.resolveReference(file.symbol);
     const functionSymbol = t.resolveReference(fileSymbol.exports!.foo);
-    expect(functionSymbol.symbolString).to.eql('foo');
+    expect(functionSymbol.text).to.eql('foo');
     expect(functionSymbol.flags).to.eql(['Function'], 'Regarded as a function');
 
     const functionType = t.resolveReference(functionSymbol.type);
-    expect(functionType.typeString).to.eql('(...parts: string[]) => string');
+    expect(functionType.text).to.eql('(...parts: string[]) => string');
     expect(functionType.flags).to.deep.eq(['Object']);
 
     expect(functionType.callSignatures!.length).to.eql(1);
     const [callSig] = functionType.callSignatures!;
-    expect(callSig.typeString).to.eql('(...parts: string[]): string');
+    expect(callSig.text).to.eql('(...parts: string[]): string');
     expect(callSig.parameters!.length).to.eql(1);
     expect(callSig.hasRestParameter).to.eql(true);
     const [firstParamSym] = callSig.parameters!.map(p => t.resolveReference(p));
     expect(firstParamSym.name).to.eq('parts');
     const firstParamType = t.resolveReference(firstParamSym.type);
-    expect(firstParamType.typeString).to.eq('string[]');
+    expect(firstParamType.text).to.eq('string[]');
     const returnType = t.resolveReference(callSig.returnType!);
-    expect(returnType.typeString).to.eq('string');
+    expect(returnType.text).to.eq('string');
 
     t.cleanup();
   }
@@ -70,24 +70,24 @@ export class FunctionAnalysisTests {
     const file = t.sourceFile();
     const fileSymbol = t.resolveReference(file.symbol);
     const functionSymbol = t.resolveReference(fileSymbol.exports!.foo);
-    expect(functionSymbol.symbolString).to.eql('foo');
+    expect(functionSymbol.text).to.eql('foo');
     expect(functionSymbol.flags).to.eql(['Function'], 'Regarded as a function');
 
     const functionType = t.resolveReference(functionSymbol.type);
-    expect(functionType.typeString).to.eql('(str: string) => string');
+    expect(functionType.text).to.eql('(str: string) => string');
     expect(functionType.flags).to.deep.eq(['Object']);
 
     expect(functionType.callSignatures!.length).to.eql(1);
     const [callSig] = functionType.callSignatures!;
-    expect(callSig.typeString).to.eql('(str: string): string');
+    expect(callSig.text).to.eql('(str: string): string');
     expect(callSig.parameters!.length).to.eql(1);
     expect(callSig.hasRestParameter).to.eql(false);
     const paramSym = t.resolveReference(callSig.parameters![0]);
     expect(paramSym.name).to.eq('str');
     const paramType = t.resolveReference(paramSym.type);
-    expect(paramType.typeString).to.eq('string');
+    expect(paramType.text).to.eq('string');
     const returnType = t.resolveReference(callSig.returnType!);
-    expect(returnType.typeString).to.eq('string');
+    expect(returnType.text).to.eq('string');
 
     t.cleanup();
   }
@@ -106,11 +106,11 @@ export class FunctionAnalysisTests {
     const file = t.sourceFile();
     const fileSymbol = t.resolveReference(file.symbol);
     const functionSymbol = t.resolveReference(fileSymbol.exports!.adder);
-    expect(functionSymbol.symbolString).to.eql('adder');
+    expect(functionSymbol.text).to.eql('adder');
     expect(functionSymbol.flags).to.eql(['Function'], 'Regarded as a function');
 
     const functionType = t.resolveReference(functionSymbol.type);
-    expect(functionType.typeString).to.eql(
+    expect(functionType.text).to.eql(
       '{ (a: string, b: string): string; (a: number, b: number): number; }',
     );
     expect(functionType.flags).to.deep.eq(['Object']);
@@ -118,31 +118,31 @@ export class FunctionAnalysisTests {
     expect(functionType.callSignatures!.length).to.eql(2);
 
     const [callSig1, callSig2] = functionType.callSignatures!;
-    expect(callSig1.typeString).to.eql('(a: string, b: string): string');
+    expect(callSig1.text).to.eql('(a: string, b: string): string');
     expect(callSig1.parameters!.length).to.eql(2);
     const [sig1Param1, sig1Param2] = callSig1.parameters!.map(p => t.resolveReference(p));
     const [sig1Param1Type, sig1Param2Type] = [sig1Param1, sig1Param2].map(s =>
       t.resolveReference(s.type),
     );
     expect(sig1Param1.name).to.eq('a');
-    expect(sig1Param1Type.typeString).to.eq('string');
+    expect(sig1Param1Type.text).to.eq('string');
     expect(sig1Param2.name).to.eq('b');
-    expect(sig1Param2Type.typeString).to.eq('string');
+    expect(sig1Param2Type.text).to.eq('string');
     const sig1ReturnType = t.resolveReference(callSig1.returnType!);
-    expect(sig1ReturnType.typeString).to.eq('string');
+    expect(sig1ReturnType.text).to.eq('string');
 
-    expect(callSig2.typeString).to.eql('(a: number, b: number): number');
+    expect(callSig2.text).to.eql('(a: number, b: number): number');
     expect(callSig2.parameters!.length).to.eql(2);
     const [sig2Param1, sig2Param2] = callSig2.parameters!.map(p => t.resolveReference(p));
     const [sig2Param1Type, sig2Param2Type] = [sig2Param1, sig2Param2].map(s =>
       t.resolveReference(s.type),
     );
     expect(sig2Param1.name).to.eq('a');
-    expect(sig2Param1Type.typeString).to.eq('number');
+    expect(sig2Param1Type.text).to.eq('number');
     expect(sig2Param2.name).to.eq('b');
-    expect(sig2Param2Type.typeString).to.eq('number');
+    expect(sig2Param2Type.text).to.eq('number');
     const sig2ReturnType = t.resolveReference(callSig2.returnType!);
-    expect(sig2ReturnType.typeString).to.eq('number');
+    expect(sig2ReturnType.text).to.eq('number');
 
     t.cleanup();
   }

--- a/packages/core/test/acceptance/functions.test.ts
+++ b/packages/core/test/acceptance/functions.test.ts
@@ -14,12 +14,12 @@ export class FunctionAnalysisTests {
     const fileSymbol = t.resolveReference(file.symbol);
     const functionSymbol = t.resolveReference(fileSymbol.exports!.foo);
     expect(functionSymbol.symbolString).to.eql('foo');
-    expect(functionSymbol.typeString).to.eql('() => string', 'has correct type');
     expect(functionSymbol.flags).to.eql(['Function'], 'Regarded as a function');
 
     const functionType = t.resolveReference(functionSymbol.type);
     expect(functionType.typeString).to.eql('() => string');
     expect(functionType.flags).to.deep.eq(['Object']);
+    expect(functionType.typeString).to.eql('() => string', 'has correct type');
 
     expect(functionType.callSignatures!.length).to.eql(1);
     const [callSig] = functionType.callSignatures!;
@@ -41,7 +41,6 @@ export class FunctionAnalysisTests {
     const fileSymbol = t.resolveReference(file.symbol);
     const functionSymbol = t.resolveReference(fileSymbol.exports!.foo);
     expect(functionSymbol.symbolString).to.eql('foo');
-    expect(functionSymbol.typeString).to.eql('(...parts: string[]) => string', 'has correct type');
     expect(functionSymbol.flags).to.eql(['Function'], 'Regarded as a function');
 
     const functionType = t.resolveReference(functionSymbol.type);
@@ -55,7 +54,8 @@ export class FunctionAnalysisTests {
     expect(callSig.hasRestParameter).to.eql(true);
     const [firstParamSym] = callSig.parameters!.map(p => t.resolveReference(p));
     expect(firstParamSym.name).to.eq('parts');
-    expect(firstParamSym.typeString).to.eq('string[]');
+    const firstParamType = t.resolveReference(firstParamSym.type);
+    expect(firstParamType.typeString).to.eq('string[]');
     const returnType = t.resolveReference(callSig.returnType!);
     expect(returnType.typeString).to.eq('string');
 
@@ -84,7 +84,8 @@ export class FunctionAnalysisTests {
     expect(callSig.hasRestParameter).to.eql(false);
     const paramSym = t.resolveReference(callSig.parameters![0]);
     expect(paramSym.name).to.eq('str');
-    expect(paramSym.typeString).to.eq('string');
+    const paramType = t.resolveReference(paramSym.type);
+    expect(paramType.typeString).to.eq('string');
     const returnType = t.resolveReference(callSig.returnType!);
     expect(returnType.typeString).to.eq('string');
 
@@ -120,20 +121,26 @@ export class FunctionAnalysisTests {
     expect(callSig1.typeString).to.eql('(a: string, b: string): string');
     expect(callSig1.parameters!.length).to.eql(2);
     const [sig1Param1, sig1Param2] = callSig1.parameters!.map(p => t.resolveReference(p));
+    const [sig1Param1Type, sig1Param2Type] = [sig1Param1, sig1Param2].map(s =>
+      t.resolveReference(s.type),
+    );
     expect(sig1Param1.name).to.eq('a');
-    expect(sig1Param1.typeString).to.eq('string');
+    expect(sig1Param1Type.typeString).to.eq('string');
     expect(sig1Param2.name).to.eq('b');
-    expect(sig1Param2.typeString).to.eq('string');
+    expect(sig1Param2Type.typeString).to.eq('string');
     const sig1ReturnType = t.resolveReference(callSig1.returnType!);
     expect(sig1ReturnType.typeString).to.eq('string');
 
     expect(callSig2.typeString).to.eql('(a: number, b: number): number');
     expect(callSig2.parameters!.length).to.eql(2);
     const [sig2Param1, sig2Param2] = callSig2.parameters!.map(p => t.resolveReference(p));
+    const [sig2Param1Type, sig2Param2Type] = [sig2Param1, sig2Param2].map(s =>
+      t.resolveReference(s.type),
+    );
     expect(sig2Param1.name).to.eq('a');
-    expect(sig2Param1.typeString).to.eq('number');
+    expect(sig2Param1Type.typeString).to.eq('number');
     expect(sig2Param2.name).to.eq('b');
-    expect(sig2Param2.typeString).to.eq('number');
+    expect(sig2Param2Type.typeString).to.eq('number');
     const sig2ReturnType = t.resolveReference(callSig2.returnType!);
     expect(sig2ReturnType.typeString).to.eq('number');
 

--- a/packages/core/test/acceptance/helpers/sanitize.ts
+++ b/packages/core/test/acceptance/helpers/sanitize.ts
@@ -45,11 +45,6 @@ export function sanitizeSymbol(
   }
   replace.forEach(rep => {
     symbol.name = symbol.name.replace(rep[0], rep[1]);
-    if (symbol.symbolString) {
-      symbol.symbolString = symbol.symbolString.replace(rep[0], rep[1]);
-    }
-    if (symbol.typeString) {
-      symbol.typeString = symbol.typeString.replace(rep[0], rep[1]);
-    }
+    symbol.symbolString = symbol.symbolString.replace(rep[0], rep[1]);
   });
 }

--- a/packages/core/test/acceptance/helpers/sanitize.ts
+++ b/packages/core/test/acceptance/helpers/sanitize.ts
@@ -11,7 +11,7 @@ export function sanitizeType(
     return;
   }
   replace.forEach(rep => {
-    type.typeString = type.typeString.replace(rep[0], rep[1]);
+    type.text = type.text.replace(rep[0], rep[1]);
   });
 }
 
@@ -45,6 +45,6 @@ export function sanitizeSymbol(
   }
   replace.forEach(rep => {
     symbol.name = symbol.name.replace(rep[0], rep[1]);
-    symbol.symbolString = symbol.symbolString.replace(rep[0], rep[1]);
+    symbol.text = symbol.text.replace(rep[0], rep[1]);
   });
 }

--- a/packages/core/test/acceptance/interface.test.ts
+++ b/packages/core/test/acceptance/interface.test.ts
@@ -16,7 +16,6 @@ export class InterfaceSerializationTests {
     const fileSymbol = t.resolveReference(file.symbol);
     const variableSymbol = t.resolveReference(fileSymbol.exports!.x);
     expect(variableSymbol.symbolString).to.eql('x');
-    expect(variableSymbol.typeString).to.eql('Foo', 'has correct type');
     expect(variableSymbol.flags).to.eql(['BlockScopedVariable'], 'Regarded as a variable');
 
     const variableType = t.resolveReference(variableSymbol.type);
@@ -27,7 +26,8 @@ export class InterfaceSerializationTests {
     expect(typePropertyNames).to.deep.eq(['num']);
     const firstProp = t.resolveReference(variableType.properties!.num);
     expect(firstProp.name).to.eql('num');
-    expect(firstProp.typeString).to.eql('number');
+    const firstPropType = t.resolveReference(firstProp.type);
+    expect(firstPropType.typeString).to.eql('number');
     t.cleanup();
   }
 
@@ -40,10 +40,10 @@ export class InterfaceSerializationTests {
     const fileSymbol = t.resolveReference(file.symbol);
     const interfaceSymbol = t.resolveReference(fileSymbol.exports!.Foo);
     expect(interfaceSymbol.symbolString).to.eql('Foo');
-    expect(interfaceSymbol.typeString).to.eql('Foo', 'has correct type');
     expect(interfaceSymbol.flags).to.eql(['Interface'], 'Regarded as an interface');
 
     const interfaceType = t.resolveReference(interfaceSymbol.type);
+    expect(interfaceType.typeString).to.eql('Foo', 'has correct type');
     expect(interfaceType.typeString).to.eql('Foo');
     expect(interfaceType.flags).to.deep.eq(['Object']);
     expect(interfaceType.objectFlags).to.deep.eq(['Interface']);
@@ -52,11 +52,12 @@ export class InterfaceSerializationTests {
     const [bar, baz] = Object.keys(interfaceType.properties!).map(pName =>
       t.resolveReference(interfaceType.properties![pName]),
     );
+    const [barType, bazType] = [bar, baz].map(s => t.resolveReference(s.type));
     expect(bar.name).to.eql('bar');
-    expect(bar.typeString).to.eql('number');
+    expect(barType.typeString).to.eql('number');
     expect(bar.modifiers).to.deep.eq(undefined);
     expect(baz.name).to.eql('baz');
-    expect(baz.typeString).to.eql('Promise<string>');
+    expect(bazType.typeString).to.eql('Promise<string>');
     expect(baz.modifiers).to.deep.eq(['readonly']);
     t.cleanup();
   }

--- a/packages/core/test/acceptance/interface.test.ts
+++ b/packages/core/test/acceptance/interface.test.ts
@@ -15,11 +15,11 @@ export class InterfaceSerializationTests {
     const file = t.sourceFile();
     const fileSymbol = t.resolveReference(file.symbol);
     const variableSymbol = t.resolveReference(fileSymbol.exports!.x);
-    expect(variableSymbol.symbolString).to.eql('x');
+    expect(variableSymbol.text).to.eql('x');
     expect(variableSymbol.flags).to.eql(['BlockScopedVariable'], 'Regarded as a variable');
 
     const variableType = t.resolveReference(variableSymbol.type);
-    expect(variableType.typeString).to.eql('Foo');
+    expect(variableType.text).to.eql('Foo');
     expect(variableType.flags).to.deep.eq(['Object']);
     expect(variableType.objectFlags).to.deep.eq(['Interface']);
     const typePropertyNames = Object.keys(variableType.properties!);
@@ -27,7 +27,7 @@ export class InterfaceSerializationTests {
     const firstProp = t.resolveReference(variableType.properties!.num);
     expect(firstProp.name).to.eql('num');
     const firstPropType = t.resolveReference(firstProp.type);
-    expect(firstPropType.typeString).to.eql('number');
+    expect(firstPropType.text).to.eql('number');
     t.cleanup();
   }
 
@@ -39,12 +39,12 @@ export class InterfaceSerializationTests {
     const file = t.sourceFile();
     const fileSymbol = t.resolveReference(file.symbol);
     const interfaceSymbol = t.resolveReference(fileSymbol.exports!.Foo);
-    expect(interfaceSymbol.symbolString).to.eql('Foo');
+    expect(interfaceSymbol.text).to.eql('Foo');
     expect(interfaceSymbol.flags).to.eql(['Interface'], 'Regarded as an interface');
 
     const interfaceType = t.resolveReference(interfaceSymbol.type);
-    expect(interfaceType.typeString).to.eql('Foo', 'has correct type');
-    expect(interfaceType.typeString).to.eql('Foo');
+    expect(interfaceType.text).to.eql('Foo', 'has correct type');
+    expect(interfaceType.text).to.eql('Foo');
     expect(interfaceType.flags).to.deep.eq(['Object']);
     expect(interfaceType.objectFlags).to.deep.eq(['Interface']);
     const typePropertyNames = Object.keys(interfaceType.properties!);
@@ -54,10 +54,10 @@ export class InterfaceSerializationTests {
     );
     const [barType, bazType] = [bar, baz].map(s => t.resolveReference(s.type));
     expect(bar.name).to.eql('bar');
-    expect(barType.typeString).to.eql('number');
+    expect(barType.text).to.eql('number');
     expect(bar.modifiers).to.deep.eq(undefined);
     expect(baz.name).to.eql('baz');
-    expect(bazType.typeString).to.eql('Promise<string>');
+    expect(bazType.text).to.eql('Promise<string>');
     expect(baz.modifiers).to.deep.eq(['readonly']);
     t.cleanup();
   }

--- a/packages/core/test/acceptance/types.test.ts
+++ b/packages/core/test/acceptance/types.test.ts
@@ -16,7 +16,6 @@ export class TypeSerializationTests {
     const fileSymbol = t.resolveReference(file.symbol);
     const typeSymbol = t.resolveReference(fileSymbol.exports!.x);
     expect(typeSymbol.symbolString).to.eql('x');
-    expect(typeSymbol.typeString).to.eql('{ width: number; height: number; }', 'has correct type');
     expect(typeSymbol.flags).to.eql(['BlockScopedVariable'], 'Regarded as a variable');
 
     const typeType = t.resolveReference(typeSymbol.type);
@@ -34,11 +33,10 @@ export class TypeSerializationTests {
     const fileSymbol = t.resolveReference(file.symbol);
     const typeSymbol = t.resolveReference(fileSymbol.exports!.Dict);
     expect(typeSymbol.symbolString).to.eql('Dict');
-    expect(typeSymbol.typeString).to.eql('Dict<T>', 'has correct type');
     expect(typeSymbol.flags).to.eql(['TypeAlias'], 'Regarded as a type alias');
 
     const typeType = t.resolveReference(typeSymbol.type);
-    expect(typeType.typeString).to.eql('Dict<T>');
+    expect(typeType.typeString).to.eql('Dict<T>', 'has correct type');
     expect(typeType.flags).to.deep.eq(['Object']);
     const [typeParam] = typeType.typeParameters!.map(tp => t.resolveReference(tp));
     expect(typeParam.typeString).to.eq('T');
@@ -58,7 +56,6 @@ export class TypeSerializationTests {
     const fileSymbol = t.resolveReference(file.symbol);
     const typeSymbol = t.resolveReference(fileSymbol.exports!.Dict);
     expect(typeSymbol.symbolString).to.eql('Dict');
-    expect(typeSymbol.typeString).to.eql('Dict<T>', 'has correct type');
     expect(typeSymbol.flags).to.eql(['TypeAlias'], 'Regarded as a type alias');
 
     const typeType = t.resolveReference(typeSymbol.type);
@@ -81,7 +78,6 @@ export class TypeSerializationTests {
     const fileSymbol = t.resolveReference(file.symbol);
     const typeSymbol = t.resolveReference(fileSymbol.exports!.StringNumberOrBoolean);
     expect(typeSymbol.symbolString).to.eql('StringNumberOrBoolean');
-    expect(typeSymbol.typeString).to.eql('StringNumberOrBoolean', 'has correct type');
     expect(typeSymbol.flags).to.eql(['TypeAlias'], 'Regarded as a type alias');
 
     const typeType = t.resolveReference(typeSymbol.type);
@@ -112,7 +108,6 @@ export class TypeSerializationTests {
     const fileSymbol = t.resolveReference(file.symbol);
     const typeSymbol = t.resolveReference(fileSymbol.exports!.Split);
     expect(typeSymbol.symbolString).to.eql('Split');
-    expect(typeSymbol.typeString).to.eql('Split', 'has correct type');
     expect(typeSymbol.flags).to.eql(['TypeAlias'], 'Regarded as a type alias');
 
     const typeType = t.resolveReference(typeSymbol.type);

--- a/packages/core/test/acceptance/types.test.ts
+++ b/packages/core/test/acceptance/types.test.ts
@@ -15,11 +15,11 @@ export class TypeSerializationTests {
     const file = t.sourceFile();
     const fileSymbol = t.resolveReference(file.symbol);
     const typeSymbol = t.resolveReference(fileSymbol.exports!.x);
-    expect(typeSymbol.symbolString).to.eql('x');
+    expect(typeSymbol.text).to.eql('x');
     expect(typeSymbol.flags).to.eql(['BlockScopedVariable'], 'Regarded as a variable');
 
     const typeType = t.resolveReference(typeSymbol.type);
-    expect(typeType.typeString).to.eql('{ width: number; height: number; }');
+    expect(typeType.text).to.eql('{ width: number; height: number; }');
     expect(typeType.flags).to.deep.eq(['Object']);
     t.cleanup();
   }
@@ -32,18 +32,18 @@ export class TypeSerializationTests {
     const file = t.sourceFile();
     const fileSymbol = t.resolveReference(file.symbol);
     const typeSymbol = t.resolveReference(fileSymbol.exports!.Dict);
-    expect(typeSymbol.symbolString).to.eql('Dict');
+    expect(typeSymbol.text).to.eql('Dict');
     expect(typeSymbol.flags).to.eql(['TypeAlias'], 'Regarded as a type alias');
 
     const typeType = t.resolveReference(typeSymbol.type);
-    expect(typeType.typeString).to.eql('Dict<T>', 'has correct type');
+    expect(typeType.text).to.eql('Dict<T>', 'has correct type');
     expect(typeType.flags).to.deep.eq(['Object']);
     const [typeParam] = typeType.typeParameters!.map(tp => t.resolveReference(tp));
-    expect(typeParam.typeString).to.eq('T');
+    expect(typeParam.text).to.eq('T');
     expect(!!typeParam.constraint).to.eq(false);
     const stringIndexType = t.resolveReference(typeType.stringIndexType);
     // TODO: this should really be T | undefined, although it's coming through as T
-    expect(stringIndexType.typeString).to.include('T');
+    expect(stringIndexType.text).to.include('T');
     t.cleanup();
   }
 
@@ -55,17 +55,17 @@ export class TypeSerializationTests {
     const file = t.sourceFile();
     const fileSymbol = t.resolveReference(file.symbol);
     const typeSymbol = t.resolveReference(fileSymbol.exports!.Dict);
-    expect(typeSymbol.symbolString).to.eql('Dict');
+    expect(typeSymbol.text).to.eql('Dict');
     expect(typeSymbol.flags).to.eql(['TypeAlias'], 'Regarded as a type alias');
 
     const typeType = t.resolveReference(typeSymbol.type);
-    expect(typeType.typeString).to.eql('Dict<T>');
+    expect(typeType.text).to.eql('Dict<T>');
     expect(typeType.flags).to.deep.eq(['Object']);
     const [typeParam] = typeType.typeParameters!.map(tp => t.resolveReference(tp));
-    expect(typeParam.typeString).to.eq('T');
-    expect(t.resolveReference(typeParam.constraint).typeString).to.eq('"foo" | "bar" | "baz"');
+    expect(typeParam.text).to.eq('T');
+    expect(t.resolveReference(typeParam.constraint).text).to.eq('"foo" | "bar" | "baz"');
     const stringIndexType = t.resolveReference(typeType.stringIndexType);
-    expect(stringIndexType.typeString).to.include('T');
+    expect(stringIndexType.text).to.include('T');
     t.cleanup();
   }
 
@@ -77,11 +77,11 @@ export class TypeSerializationTests {
     const file = t.sourceFile();
     const fileSymbol = t.resolveReference(file.symbol);
     const typeSymbol = t.resolveReference(fileSymbol.exports!.StringNumberOrBoolean);
-    expect(typeSymbol.symbolString).to.eql('StringNumberOrBoolean');
+    expect(typeSymbol.text).to.eql('StringNumberOrBoolean');
     expect(typeSymbol.flags).to.eql(['TypeAlias'], 'Regarded as a type alias');
 
     const typeType = t.resolveReference(typeSymbol.type);
-    expect(typeType.typeString).to.eql('StringNumberOrBoolean');
+    expect(typeType.text).to.eql('StringNumberOrBoolean');
     expect(typeType.flags).to.deep.eq(['Union']);
     expect(!!typeType.typeParameters).to.eq(false);
 
@@ -89,9 +89,9 @@ export class TypeSerializationTests {
 
     expect(unionParts.length).to.eql(3);
     const [l, c, r] = unionParts;
-    expect(l.typeString).to.eq('string');
-    expect(c.typeString).to.eq('number');
-    expect(r.typeString).to.eq('true');
+    expect(l.text).to.eq('string');
+    expect(c.text).to.eq('number');
+    expect(r.text).to.eq('true');
     expect(l.flags).to.deep.eq(['String']);
     expect(c.flags).to.deep.eq(['Number']);
     expect(r.flags).to.deep.eq(['BooleanLiteral']);
@@ -107,11 +107,11 @@ export class TypeSerializationTests {
     const file = t.sourceFile();
     const fileSymbol = t.resolveReference(file.symbol);
     const typeSymbol = t.resolveReference(fileSymbol.exports!.Split);
-    expect(typeSymbol.symbolString).to.eql('Split');
+    expect(typeSymbol.text).to.eql('Split');
     expect(typeSymbol.flags).to.eql(['TypeAlias'], 'Regarded as a type alias');
 
     const typeType = t.resolveReference(typeSymbol.type);
-    expect(typeType.typeString).to.eql('Split');
+    expect(typeType.text).to.eql('Split');
     expect(!!typeType.typeParameters).to.eq(false);
 
     t.cleanup();

--- a/packages/core/test/acceptance/variable.test.ts
+++ b/packages/core/test/acceptance/variable.test.ts
@@ -16,7 +16,6 @@ export class VariableSerializationTests {
     expect(Object.keys(fileSymbol.exports!)).to.deep.eq(['x']);
     const variableSymbol = t.resolveReference(fileSymbol.exports!.x);
     expect(variableSymbol.symbolString).to.eql('x');
-    expect(variableSymbol.typeString).to.eql('number', 'has type of number');
     expect(variableSymbol.flags).to.eql(['BlockScopedVariable'], 'Regarded as a variable');
     expect(variableSymbol.modifiers).to.eql(undefined, 'No modifiers');
 
@@ -35,7 +34,6 @@ export class VariableSerializationTests {
     const fileSymbol = t.resolveReference(file.symbol);
     const variableSymbol = t.resolveReference(fileSymbol.exports!.x);
     expect(variableSymbol.symbolString).to.eql('x');
-    expect(variableSymbol.typeString).to.eql('1', 'has type of 1');
     expect(variableSymbol.flags).to.eql(['BlockScopedVariable'], 'Regarded as a variable');
     expect(variableSymbol.modifiers).to.eql(undefined, 'No modifiers');
 
@@ -54,7 +52,6 @@ export class VariableSerializationTests {
     const fileSymbol = t.resolveReference(file.symbol);
     const variableSymbol = t.resolveReference(fileSymbol.exports!.x);
     expect(variableSymbol.symbolString).to.eql('x');
-    expect(variableSymbol.typeString).to.eql('number', 'has type of number');
     expect(variableSymbol.flags).to.eql(['BlockScopedVariable'], 'Regarded as a variable');
 
     const variableType = t.resolveReference(variableSymbol.type);
@@ -72,7 +69,6 @@ export class VariableSerializationTests {
     const fileSymbol = t.resolveReference(file.symbol);
     const variableSymbol = t.resolveReference(fileSymbol.exports!.x);
     expect(variableSymbol.symbolString).to.eql('x');
-    expect(variableSymbol.typeString).to.eql('string | number', 'has correct type');
     expect(variableSymbol.flags).to.eql(['BlockScopedVariable'], 'Regarded as a variable');
 
     const variableType = t.resolveReference(variableSymbol.type);
@@ -90,7 +86,6 @@ export class VariableSerializationTests {
     const fileSymbol = t.resolveReference(file.symbol);
     const variableSymbol = t.resolveReference(fileSymbol.exports!.x);
     expect(variableSymbol.symbolString).to.eql('x');
-    expect(variableSymbol.typeString).to.eql('Promise<number>', 'has correct type');
     expect(variableSymbol.flags).to.eql(['BlockScopedVariable'], 'Regarded as a variable');
 
     const variableType = t.resolveReference(variableSymbol.type);

--- a/packages/core/test/acceptance/variable.test.ts
+++ b/packages/core/test/acceptance/variable.test.ts
@@ -15,12 +15,12 @@ export class VariableSerializationTests {
     expect(fileSymbol.exports).to.be.an('object', "file symbol's exports is an object");
     expect(Object.keys(fileSymbol.exports!)).to.deep.eq(['x']);
     const variableSymbol = t.resolveReference(fileSymbol.exports!.x);
-    expect(variableSymbol.symbolString).to.eql('x');
+    expect(variableSymbol.text).to.eql('x');
     expect(variableSymbol.flags).to.eql(['BlockScopedVariable'], 'Regarded as a variable');
     expect(variableSymbol.modifiers).to.eql(undefined, 'No modifiers');
 
     const variableType = t.resolveReference(variableSymbol.type);
-    expect(variableType.typeString).to.eql('number');
+    expect(variableType.text).to.eql('number');
     expect(variableType.flags).to.deep.eq(['Number']);
     t.cleanup();
   }
@@ -33,12 +33,12 @@ export class VariableSerializationTests {
     const file = t.sourceFile();
     const fileSymbol = t.resolveReference(file.symbol);
     const variableSymbol = t.resolveReference(fileSymbol.exports!.x);
-    expect(variableSymbol.symbolString).to.eql('x');
+    expect(variableSymbol.text).to.eql('x');
     expect(variableSymbol.flags).to.eql(['BlockScopedVariable'], 'Regarded as a variable');
     expect(variableSymbol.modifiers).to.eql(undefined, 'No modifiers');
 
     const variableType = t.resolveReference(variableSymbol.type);
-    expect(variableType.typeString).to.eql('1');
+    expect(variableType.text).to.eql('1');
     expect(variableType.flags).to.deep.eq(['NumberLiteral']);
     t.cleanup();
   }
@@ -51,11 +51,11 @@ export class VariableSerializationTests {
     const file = t.sourceFile();
     const fileSymbol = t.resolveReference(file.symbol);
     const variableSymbol = t.resolveReference(fileSymbol.exports!.x);
-    expect(variableSymbol.symbolString).to.eql('x');
+    expect(variableSymbol.text).to.eql('x');
     expect(variableSymbol.flags).to.eql(['BlockScopedVariable'], 'Regarded as a variable');
 
     const variableType = t.resolveReference(variableSymbol.type);
-    expect(variableType.typeString).to.eql('number');
+    expect(variableType.text).to.eql('number');
     expect(variableType.flags).to.deep.eq(['Number']);
     t.cleanup();
   }
@@ -68,11 +68,11 @@ export class VariableSerializationTests {
     const file = t.sourceFile();
     const fileSymbol = t.resolveReference(file.symbol);
     const variableSymbol = t.resolveReference(fileSymbol.exports!.x);
-    expect(variableSymbol.symbolString).to.eql('x');
+    expect(variableSymbol.text).to.eql('x');
     expect(variableSymbol.flags).to.eql(['BlockScopedVariable'], 'Regarded as a variable');
 
     const variableType = t.resolveReference(variableSymbol.type);
-    expect(variableType.typeString).to.eql('string | number');
+    expect(variableType.text).to.eql('string | number');
     expect(variableType.flags).to.deep.eq(['Union']);
     t.cleanup();
   }
@@ -85,11 +85,11 @@ export class VariableSerializationTests {
     const file = t.sourceFile();
     const fileSymbol = t.resolveReference(file.symbol);
     const variableSymbol = t.resolveReference(fileSymbol.exports!.x);
-    expect(variableSymbol.symbolString).to.eql('x');
+    expect(variableSymbol.text).to.eql('x');
     expect(variableSymbol.flags).to.eql(['BlockScopedVariable'], 'Regarded as a variable');
 
     const variableType = t.resolveReference(variableSymbol.type);
-    expect(variableType.typeString).to.eql('Promise<number>');
+    expect(variableType.text).to.eql('Promise<number>');
     expect(variableType.flags).to.deep.eq(['Object']);
     expect(variableType.libName).to.eq('lib.es5.d.ts');
     expect(variableType.objectFlags).to.deep.eq(['Reference']);
@@ -106,18 +106,18 @@ export class VariableSerializationTests {
     const file = t.sourceFile();
     const fileSymbol = t.resolveReference(file.symbol);
     const variableSymbol = t.resolveReference(fileSymbol.exports!.x);
-    expect(variableSymbol.symbolString).to.eql('x');
+    expect(variableSymbol.text).to.eql('x');
     expect(variableSymbol.flags).to.eql(['BlockScopedVariable'], 'Regarded as a variable');
 
     const variableType = t.resolveReference(variableSymbol.type);
-    expect(variableType.typeString).to.eql('{ p: Promise<number[]>; }');
+    expect(variableType.text).to.eql('{ p: Promise<number[]>; }');
     expect(variableType.flags).to.deep.eq(['Object']);
     expect(variableType.objectFlags).to.deep.eq(['Anonymous']);
     expect(Object.keys(variableType.properties!)).to.deep.eq(['p']);
     const pSym = t.resolveReference(variableType.properties!.p);
-    expect(pSym.symbolString).to.eq('p');
+    expect(pSym.text).to.eq('p');
     const pTyp = t.resolveReference(pSym.type);
-    expect(pTyp.typeString).to.eq('Promise<number[]>');
+    expect(pTyp.text).to.eq('Promise<number[]>');
     expect(pTyp.libName).to.eq('lib.es5.d.ts');
     t.cleanup();
   }
@@ -130,21 +130,21 @@ export class VariableSerializationTests {
     const file = t.sourceFile();
     const fileSymbol = t.resolveReference(file.symbol);
     const variableSymbol = t.resolveReference(fileSymbol.exports!.x);
-    expect(variableSymbol.symbolString).to.eql('x');
+    expect(variableSymbol.text).to.eql('x');
     expect(variableSymbol.flags).to.eql(['BlockScopedVariable'], 'Regarded as a variable');
 
     const variableType = t.resolveReference(variableSymbol.type);
-    expect(variableType.typeString).to.eql('Pick<Promise<number>, "then">');
+    expect(variableType.text).to.eql('Pick<Promise<number>, "then">');
     expect(variableType.flags).to.deep.eq(['Object']);
     expect(variableType.objectFlags).to.deep.eq(['Mapped', 'Instantiated']);
     expect(variableType.typeParameters).to.have.lengthOf(1);
     expect(variableType.constraint).to.have.lengthOf(2);
     const constraint = t.resolveReference(variableType.constraint);
-    expect(constraint.typeString).to.eq('"then"');
+    expect(constraint.text).to.eq('"then"');
     const [typeParam] = variableType.typeParameters!.map(tp => t.resolveReference(tp));
-    expect(typeParam.typeString).to.eql('P');
+    expect(typeParam.text).to.eql('P');
     const modType = t.resolveReference(variableType.modifiersType);
-    expect(modType.typeString).to.eq('Promise<number>');
+    expect(modType.text).to.eq('Promise<number>');
     t.cleanup();
   }
 }

--- a/packages/formatter/src/index.ts
+++ b/packages/formatter/src/index.ts
@@ -13,4 +13,8 @@ export {
   FormattedSymbolRef,
   FormattedTypeRef,
   FormatterRefRegistry,
+  FormattedSymbolKind,
+  FormattedTypeKind,
+  FormattedObjectTypeKind,
+  FormattedTypeConditionInfo,
 } from './types';

--- a/packages/formatter/src/symbol.ts
+++ b/packages/formatter/src/symbol.ts
@@ -152,13 +152,14 @@ export default function formatSymbol(
     external,
     documentation,
     isAbstract,
-    symbolString,
+    text,
     relatedSymbols,
   } = symbol;
   const id = refId(ref);
   const info: FormattedSymbol = {
     id,
     kind: determineSymbolKind(symbol),
+    text,
     name: name || '(anonymous)',
   };
   Object.assign(
@@ -177,9 +178,6 @@ export default function formatSymbol(
   }
   if (_rawFlags.indexOf('Transient') >= 0) {
     info.isTransient = true;
-  }
-  if (symbolString) {
-    info.text = symbolString;
   }
   if (location) {
     info.location = convertLocation(wo, collector, location);

--- a/packages/formatter/src/symbol.ts
+++ b/packages/formatter/src/symbol.ts
@@ -69,7 +69,13 @@ function formatSymbolDecorators(
   return out;
 }
 
-type MODIFIER_PROPERTIES = 'isExported' | 'accessModifier' | 'isStatic' | 'isConst' | 'isAsync';
+type MODIFIER_PROPERTIES =
+  | 'isExported'
+  | 'accessModifier'
+  | 'isStatic'
+  | 'isConst'
+  | 'isAsync'
+  | 'isReadOnly';
 
 function formatSymbolModifiers(modifiers?: string[]): Pick<FormattedSymbol, MODIFIER_PROPERTIES> {
   if (!modifiers) {
@@ -89,6 +95,9 @@ function formatSymbolModifiers(modifiers?: string[]): Pick<FormattedSymbol, MODI
         break;
       case 'const':
         out.isConst = true;
+        break;
+      case 'readonly':
+        out.isReadOnly = true;
         break;
       case 'static':
         out.isStatic = true;

--- a/packages/formatter/src/type.ts
+++ b/packages/formatter/src/type.ts
@@ -285,7 +285,7 @@ export default function formatType(
   collector: DataCollector,
 ): FormattedType {
   const {
-    typeString,
+    text,
     objectFlags,
     properties,
     libName,
@@ -298,7 +298,7 @@ export default function formatType(
   const { kind, other: otherKindData } = determineTypeKind(type);
   const typeInfo: FormattedType = {
     id: refId(ref),
-    text: typeString,
+    text,
     kind,
     isThisType,
   };

--- a/packages/formatter/src/types.ts
+++ b/packages/formatter/src/types.ts
@@ -147,6 +147,7 @@ export interface FormattedSymbol<K extends FormattedSymbolKind = FormattedSymbol
   accessModifier?: 'private' | 'public' | 'protected';
   isStatic?: boolean;
   isAsync?: boolean;
+  isReadOnly?: boolean;
   isAnonymous?: boolean;
   // modifiers?: string[];
   decorators?: FormattedSymbolRef[];

--- a/packages/formatter/test/formatters/source-file.test.ts
+++ b/packages/formatter/test/formatters/source-file.test.ts
@@ -56,6 +56,7 @@ export class SourceFileFormatterTests {
           name: 'module.ts',
           entity: 'symbol',
           id: '12345',
+          symbolString: 'a stringified module',
           flags: ['module'],
         },
       },

--- a/packages/formatter/test/formatters/source-file.test.ts
+++ b/packages/formatter/test/formatters/source-file.test.ts
@@ -56,7 +56,7 @@ export class SourceFileFormatterTests {
           name: 'module.ts',
           entity: 'symbol',
           id: '12345',
-          symbolString: 'a stringified module',
+          text: 'a stringified module',
           flags: ['module'],
         },
       },

--- a/packages/formatter/test/public-api-surface.test.ts
+++ b/packages/formatter/test/public-api-surface.test.ts
@@ -13,6 +13,11 @@ export class PublicApiSurface {
 
   @test
   public 'only intended exports'(): void {
-    expect(Object.keys(Exports).sort()).to.deep.eq(['formatWalkerOutput']);
+    expect(Object.keys(Exports).sort()).to.deep.eq([
+      'FormattedObjectTypeKind',
+      'FormattedSymbolKind',
+      'FormattedTypeKind',
+      'formatWalkerOutput',
+    ]);
   }
 }

--- a/packages/utils/src/checks.ts
+++ b/packages/utils/src/checks.ts
@@ -83,6 +83,10 @@ export function isPresent(obj: any): boolean {
   return !isBlank(obj);
 }
 
-export function isDefined<T>(t: T | null | undefined): t is T {
+export function isDefined<T>(t: T | undefined): t is T {
   return typeof t !== 'undefined';
+}
+
+export function isNotNull<T>(t: T | null): t is T {
+  return t !== null;
 }

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -2,7 +2,7 @@ export { default as UnreachableError } from './errors/unreachable';
 export { default as InvalidArgumentsError } from './errors/invalid-arguments';
 export { some, all, isArray, forEach } from './array';
 export { Result, ErrorResult, SuccessResult, TextFileReader, FileExistenceChecker } from './types';
-export { isBlank, isPresent, isEmpty, isNone, isDefined } from './checks';
+export { isBlank, isPresent, isEmpty, isNone, isDefined, isNotNull } from './checks';
 export { createQueue, Queue } from './deferred-processing/queue';
 export { Ref, RefFor, AnyRef, refType, refId, isRef, createRef } from './deferred-processing/ref';
 export { timeout } from './promise';

--- a/packages/utils/test/checks.test.ts
+++ b/packages/utils/test/checks.test.ts
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 import { suite, test } from 'mocha-typescript';
-import { isBlank, isEmpty, isNone, isPresent } from '../src/checks';
+import { isBlank, isDefined, isEmpty, isNone, isNotNull, isPresent } from '../src/checks';
 
 @suite('Simple predicates')
 export class SimpleChecks {
@@ -15,6 +15,34 @@ export class SimpleChecks {
     expect(isEmpty({ length: 33 })).to.eql(false);
     expect(isEmpty(() => ({}))).to.eql(false);
     expect(isEmpty(new Map([['a', 1]]))).to.eql(false);
+  }
+
+  @test
+  public 'isNotNull tests'(): void {
+    expect(isNotNull(0)).to.eql(true);
+    expect(isNotNull(null)).to.eql(false);
+    expect(isNotNull(undefined)).to.eql(true);
+    expect(isNotNull([])).to.eql(true);
+    expect(isNotNull({ size: 0 })).to.eql(true);
+    expect(isNotNull({ size: 33 })).to.eql(true);
+    expect(isNotNull({ length: 0 })).to.eql(true);
+    expect(isNotNull({ length: 33 })).to.eql(true);
+    expect(isNotNull((): string => 'foo')).to.eql(true);
+    expect(isNotNull(new Map([['a', 1]]))).to.eql(true);
+  }
+
+  @test
+  public 'isDefined tests'(): void {
+    expect(isDefined(0)).to.eql(true);
+    expect(isDefined(null)).to.eql(true);
+    expect(isDefined(undefined)).to.eql(false);
+    expect(isDefined([])).to.eql(true);
+    expect(isDefined({ size: 0 })).to.eql(true);
+    expect(isDefined({ size: 33 })).to.eql(true);
+    expect(isDefined({ length: 0 })).to.eql(true);
+    expect(isDefined({ length: 33 })).to.eql(true);
+    expect(isDefined((): string => 'foo')).to.eql(true);
+    expect(isDefined(new Map([['a', 1]]))).to.eql(true);
   }
 
   @test


### PR DESCRIPTION
This PR fixes a bug where modifiers and decorators of symbols wouldn't be serialized if their types were on the serialization boundary