### PR TITLE
Remove mocha-typescript

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -56,7 +56,6 @@
     "eslint-plugin-typescript": "0.14.0",
     "hook-std": "1.2.0",
     "mocha": "5.2.0",
-    "mocha-typescript": "1.1.17",
     "nyc": "13.3.0",
     "remark-cli": "6.0.1",
     "remark-lint": "6.0.4",

--- a/packages/cli/test/cli-utils.test.ts
+++ b/packages/cli/test/cli-utils.test.ts
@@ -1,19 +1,17 @@
 import { expect } from 'chai';
 import * as commander from 'commander';
-import { suite, test } from 'mocha-typescript';
+import { describe, it } from 'mocha';
 import { buildProgram, runAction, timeString } from '../src/cli';
 
-@suite
-export class CliUtilTests {
-  @test
-  public async 'program builds without error'(): Promise<void> {
+describe('Cli utilities tests', () => {
+  it('program builds without error', async () => {
     let helpStr: string = '';
     const prog = buildProgram().parse([]);
     prog.outputHelp((str: string) => {
       helpStr = str;
       return str;
     });
-    await new Promise((res) => setTimeout(res, 100));
+    await new Promise(res => setTimeout(res, 100));
     expect(helpStr.length).to.be.greaterThan(0);
     expect(helpStr).to.eql(`Usage: code-to-json [options] [entries...]
 
@@ -25,19 +23,17 @@ Options:
   --format [fmt]       data format (default: "formatted")
   -h, --help           output usage information
 `);
-  }
+  });
 
-  @test
-  public async 'timeString tests'(): Promise<void> {
+  it('timeString tests', async () => {
     const start = process.hrtime();
-    await new Promise((res) => setTimeout(res, 100));
+    await new Promise(res => setTimeout(res, 100));
     const delta = process.hrtime(start);
     const s = timeString(delta, 'test time');
     expect(s).to.contain(' ms (test time)');
-  }
+  });
 
-  @test
-  public async 'runAction successful scenario'(): Promise<void> {
+  it('runAction successful scenario', async () => {
     const cmd = commander.name('foo');
     const logs: string[] = [];
     function log(str: string): void {
@@ -55,17 +51,16 @@ Options:
     await a([], cmd);
     expect(invocationCt).to.eq(1);
     expect(
-      logs.map((s) =>
+      logs.map(s =>
         s
           .substr(s.indexOf('(') + 1)
           .replace(')', '')
           .trim(),
       ),
     ).to.deep.eq(['boot time', 'extraction time']);
-  }
+  });
 
-  @test
-  public async 'runAction runtime error scenario'(): Promise<void> {
+  it('runAction runtime error scenario', async () => {
     const cmd = commander.name('foo');
     const logs: string[] = [];
     function log(str: string): void {
@@ -81,7 +76,7 @@ Options:
       log,
     );
     expect(!!a).to.eql(true, 'action is truthy');
-    expect(logs.map((s) => s.substr(s.indexOf(')') + 1).trim())).to.deep.eq([]);
+    expect(logs.map(s => s.substr(s.indexOf(')') + 1).trim())).to.deep.eq([]);
 
     try {
       await a([], cmd);
@@ -90,5 +85,5 @@ Options:
       expect(invocationCt).to.eq(1);
       expect(true).to.eql(true);
     }
-  }
-}
+  });
+});

--- a/packages/cli/test/cli.test.ts
+++ b/packages/cli/test/cli.test.ts
@@ -2,8 +2,8 @@ import { setupTestCase } from '@code-to-json/test-helpers';
 import { expect } from 'chai';
 import { spawnSync, SpawnSyncReturns } from 'child_process';
 import * as fs from 'fs';
-import { slow, suite, test } from 'mocha-typescript';
 import * as path from 'path';
+import { describe, it } from 'mocha';
 
 function runCli(args?: string[]): SpawnSyncReturns<Buffer> {
   return spawnSync('./bin/code-to-json', args, { shell: true });
@@ -26,7 +26,7 @@ const SAMPLE_PROJECT_CODE = {
 "include": ["src"]
 }
 `,
-  "src": {
+  src: {
     'index.ts': `/**
 * This is a variable with an explicit type
 */
@@ -35,90 +35,74 @@ const constWithExplicitType: string = 'foo';
   },
 };
 
-const disableIf: (predicate: boolean) => ClassDecorator = (predicate) => (target) => {
-  if (predicate) {
-    Object.getOwnPropertyNames(target.prototype).forEach((methodName) => {
-      if (methodName === 'constructor') {
-        return;
-      }
-      // eslint-disable-next-line no-param-reassign
-      target.prototype[methodName] = () => {
-        expect(true).to.eq(true);
-      };
+if (!process.env.AZURE_HTTP_USER_AGENT) {
+  describe('CLI tests', () => {
+    it('--help prints out usage information', async () => {
+      expect(
+        runCli(['--help'])
+          .stdout.toString()
+          .trim(),
+      ).contains('Usage: code-to-json [options] [entries...]');
     });
-  }
-};
 
-@suite
-@slow(2000)
-@disableIf(!!process.env.AZURE_HTTP_USER_AGENT)
-export class CliTests {
-  @test
-  public async '--help prints out usage information'(): Promise<void> {
-    expect(
-      runCli(['--help'])
-        .stdout.toString()
-        .trim(),
-    ).contains('Usage: code-to-json [options] [entries...]');
-  }
+    it('failure to specify where project exists provides appropriate feedback', async () => {
+      expect(
+        runCli()
+          .stderr.toString()
+          .trim(),
+      ).contains('Either --project <path> or entries glob(s) must be defined');
+    });
 
-  @test
-  public async 'failure to specify where project exists provides appropriate feedback'(): Promise<
-    void
-  > {
-    expect(
-      runCli()
-        .stderr.toString()
-        .trim(),
-    ).contains('Either --project <path> or entries glob(s) must be defined');
-  }
+    it('tsconfig-driven project', async () => {
+      const testCase = await setupTestCase(SAMPLE_PROJECT_CODE, ['src/index.ts']);
+      const { rootPath, cleanup } = testCase;
+      expect(rootPath).to.have.length.greaterThan(5);
+      runCli(['--project', rootPath, '--out', path.join(rootPath, 'out')]);
+      expect(fs.statSync(path.join(rootPath, 'out')).isDirectory()).to.eq(
+        true,
+        'output subdirectory exists',
+      );
+      const formattedStat = fs.statSync(path.join(rootPath, 'out', 'formatted.json'));
+      expect(formattedStat.isFile()).to.eq(true, 'formatted JSON exists');
+      expect(formattedStat.size).to.be.gt(100, 'formatted JSON is not empty');
 
-  @test
-  public async 'tsconfig-driven project'(): Promise<void> {
-    const testCase = await setupTestCase(SAMPLE_PROJECT_CODE, ['src/index.ts']);
-    const { rootPath, cleanup } = testCase;
-    expect(rootPath).to.have.length.greaterThan(5);
-    runCli(['--project', rootPath, '--out', path.join(rootPath, 'out')]);
-    expect(fs.statSync(path.join(rootPath, 'out')).isDirectory()).to.eq(
-      true,
-      'output subdirectory exists',
-    );
-    const formattedStat = fs.statSync(path.join(rootPath, 'out', 'formatted.json'));
-    expect(formattedStat.isFile()).to.eq(true, 'formatted JSON exists');
-    expect(formattedStat.size).to.be.gt(100, 'formatted JSON is not empty');
+      cleanup();
+    });
 
-    cleanup();
-  }
+    it('glob-driven project', async () => {
+      const testCase = await setupTestCase(SAMPLE_PROJECT_CODE, ['src/index.ts']);
+      const { rootPath, cleanup } = testCase;
+      expect(rootPath).to.have.length.greaterThan(5);
+      runCli(['--out', path.join(rootPath, 'out'), path.join(rootPath, 'src/*')]);
+      expect(fs.statSync(path.join(rootPath, 'out')).isDirectory()).to.eq(
+        true,
+        'output subdirectory exists',
+      );
+      const formattedStat = fs.statSync(path.join(rootPath, 'out', 'formatted.json'));
+      expect(formattedStat.isFile()).to.eq(true, 'formatted JSON exists');
+      expect(formattedStat.size).to.be.gt(100, 'formatted JSON is not empty');
+      cleanup();
+    });
 
-  @test
-  public async 'glob-driven project'(): Promise<void> {
-    const testCase = await setupTestCase(SAMPLE_PROJECT_CODE, ['src/index.ts']);
-    const { rootPath, cleanup } = testCase;
-    expect(rootPath).to.have.length.greaterThan(5);
-    runCli(['--out', path.join(rootPath, 'out'), path.join(rootPath, 'src/*')]);
-    expect(fs.statSync(path.join(rootPath, 'out')).isDirectory()).to.eq(
-      true,
-      'output subdirectory exists',
-    );
-    const formattedStat = fs.statSync(path.join(rootPath, 'out', 'formatted.json'));
-    expect(formattedStat.isFile()).to.eq(true, 'formatted JSON exists');
-    expect(formattedStat.size).to.be.gt(100, 'formatted JSON is not empty');
-    cleanup();
-  }
-
-  @test
-  public async '--format=raw emits raw data instead of formatted data'(): Promise<void> {
-    const testCase = await setupTestCase(SAMPLE_PROJECT_CODE, ['src/index.ts']);
-    const { rootPath, cleanup } = testCase;
-    expect(rootPath).to.have.length.greaterThan(5);
-    runCli(['--format', 'raw', '--out', path.join(rootPath, 'out'), path.join(rootPath, 'src/*')]);
-    expect(fs.statSync(path.join(rootPath, 'out')).isDirectory()).to.eq(
-      true,
-      'output subdirectory exists',
-    );
-    const rawStat = fs.statSync(path.join(rootPath, 'out', 'raw.json'));
-    expect(rawStat.isFile()).to.eq(true, 'raw JSON exists');
-    expect(rawStat.size).to.be.gt(100, 'raw JSON is not empty');
-    cleanup();
-  }
+    it('--format=raw emits raw data instead of formatted data', async () => {
+      const testCase = await setupTestCase(SAMPLE_PROJECT_CODE, ['src/index.ts']);
+      const { rootPath, cleanup } = testCase;
+      expect(rootPath).to.have.length.greaterThan(5);
+      runCli([
+        '--format',
+        'raw',
+        '--out',
+        path.join(rootPath, 'out'),
+        path.join(rootPath, 'src/*'),
+      ]);
+      expect(fs.statSync(path.join(rootPath, 'out')).isDirectory()).to.eq(
+        true,
+        'output subdirectory exists',
+      );
+      const rawStat = fs.statSync(path.join(rootPath, 'out', 'raw.json'));
+      expect(rawStat.isFile()).to.eq(true, 'raw JSON exists');
+      expect(rawStat.size).to.be.gt(100, 'raw JSON is not empty');
+      cleanup();
+    });
+  });
 }

--- a/packages/cli/test/command-utils.test.ts
+++ b/packages/cli/test/command-utils.test.ts
@@ -1,7 +1,7 @@
 import { createTempFixtureFolder, TestCaseFolder } from '@code-to-json/test-helpers';
 import { expect } from 'chai';
 import * as fs from 'fs';
-import { suite, test } from 'mocha-typescript';
+import { describe, it } from 'mocha';
 import * as path from 'path';
 import { findConfigFile } from 'typescript';
 import { createProgramFromEntryGlobs, globsToPaths } from '../src/command-utils';
@@ -25,10 +25,8 @@ async function makeWorkspace(): Promise<TestCaseFolder> {
   return workspace;
 }
 
-@suite
-export class CommandUtilsTests {
-  @test
-  public async 'globToPathsTest - positive cases'(): Promise<void> {
+describe('Command utilities tests', () => {
+  it('globToPathsTest - positive cases', async () => {
     const workspace = await makeWorkspace();
     const myGlob = path.join(workspace.rootPath, 'src', '*');
 
@@ -37,10 +35,9 @@ export class CommandUtilsTests {
     expect((await globsToPaths([myGlob], ['.ts'])).length).to.eql(2, '2 ts files found');
     expect((await globsToPaths([myGlob], ['.qq'])).length).to.eql(0, '0 qq files found');
     workspace.cleanup();
-  }
+  });
 
-  @test
-  public async 'globToPathsTest - negative case'(): Promise<void> {
+  it('globToPathsTest - negative case', async () => {
     await globsToPaths([undefined as any])
       .then(() => {
         expect(false).to.eql(true);
@@ -48,10 +45,9 @@ export class CommandUtilsTests {
       .catch((err: Error) => {
         expect(err.message).to.contain('Invalid glob');
       });
-  }
+  });
 
-  @test
-  public async tsConfigForEntryGlobsTest(): Promise<void> {
+  it('tsConfigForEntryGlobsTest', async () => {
     const workspace = await makeWorkspace();
 
     const pth = findConfigFile(
@@ -64,10 +60,9 @@ export class CommandUtilsTests {
     expect(pth).to.contain('tsconfig.json');
     expect(fs.existsSync(pth)).to.equal(true);
     workspace.cleanup();
-  }
+  });
 
-  @test
-  public async 'createProgramFromEntryGlobs - simple case'(): Promise<void> {
+  it('createProgramFromEntryGlobs - simple case', async () => {
     const workspace = await makeWorkspace();
     const myGlob = path.join(workspace.rootPath, 'src', '*');
 
@@ -77,5 +72,5 @@ export class CommandUtilsTests {
     expect(prog.getSourceFiles().filter(sf => !sf.isDeclarationFile).length).to.eql(3);
     expect(prog.getSourceFiles().length).to.be.greaterThan(3);
     workspace.cleanup();
-  }
-}
+  });
+});

--- a/packages/cli/test/command.test.ts
+++ b/packages/cli/test/command.test.ts
@@ -1,6 +1,6 @@
 import { createTempFixtureFolder, TestCaseFolder } from '@code-to-json/test-helpers';
 import { expect } from 'chai';
-import { suite, test } from 'mocha-typescript';
+import { describe, it } from 'mocha';
 import * as path from 'path';
 import generateJSONCommand from '../src/commands/generate-json';
 
@@ -21,10 +21,8 @@ async function makeWorkspace(): Promise<TestCaseFolder> {
   return workspace;
 }
 
-@suite
-export class CommandTests {
-  @test
-  public async 'run command: --project'(): Promise<void> {
+describe('Command tests', () => {
+  it('run command: --project', async () => {
     const workspace = await makeWorkspace();
     await generateJSONCommand({
       project: workspace.rootPath,
@@ -41,10 +39,9 @@ export class CommandTests {
 `,
     );
     workspace.cleanup();
-  }
+  });
 
-  @test.skip
-  public async 'run command: entries'(): Promise<void> {
+  it.skip('run command: entries', async () => {
     const workspace = await makeWorkspace();
     await generateJSONCommand({ out: path.join(workspace.rootPath, 'out') }, ['src/index.ts']);
     expect(workspace.toString()).to.eql(
@@ -58,10 +55,9 @@ export class CommandTests {
 `,
     );
     workspace.cleanup();
-  }
+  });
 
-  @test
-  public async 'run command: insufficient CLI args'(): Promise<void> {
+  it('run command: insufficient CLI args', async () => {
     const workspace = await makeWorkspace();
     try {
       await generateJSONCommand({ out: path.join(workspace.rootPath, 'out') }).then(() => {
@@ -72,5 +68,5 @@ export class CommandTests {
     }
 
     workspace.cleanup();
-  }
-}
+  });
+});

--- a/packages/cli/test/mocha.opts
+++ b/packages/cli/test/mocha.opts
@@ -1,4 +1,3 @@
---ui mocha-typescript
 --require ts-node/register
 --require source-map-support/register
 --timeout 60000

--- a/packages/cli/test/public-api-surface.test.ts
+++ b/packages/cli/test/public-api-surface.test.ts
@@ -1,16 +1,13 @@
 import { expect } from 'chai';
-import { suite, test } from 'mocha-typescript';
+import { describe, it } from 'mocha';
 import * as Exported from '../src/index';
 
-@suite
-export class PublicApiSurfaceTests {
-  @test
-  public 'runCli method exists'(): void {
+describe('public API surface tests', () => {
+  it('runCli method exists', () => {
     expect(Exported.runCli).to.be.a('function');
-  }
+  });
 
-  @test
-  public 'no extra exports'(): void {
+  it('no extra exports', () => {
     expect(Object.keys(Exported).sort()).to.eql(['generateJSONCommand', 'runCli']);
-  }
-}
+  });
+});

--- a/packages/comments/package.json
+++ b/packages/comments/package.json
@@ -38,7 +38,6 @@
     "eslint-plugin-import": "2.16.0",
     "eslint-plugin-prettier": "3.0.1",
     "mocha": "5.2.0",
-    "mocha-typescript": "1.1.17",
     "nyc": "13.3.0",
     "remark-cli": "6.0.1",
     "remark-lint": "6.0.4",

--- a/packages/comments/test/comment-whitespace.test.ts
+++ b/packages/comments/test/comment-whitespace.test.ts
@@ -1,11 +1,9 @@
 import { expect } from 'chai';
-import { suite, test } from 'mocha-typescript';
+import { describe, it } from 'mocha';
 import { parseCommentString } from '../src/index';
 
-@suite
-export class CommentWhitespaceTests {
-  @test
-  public 'simple comment with no tags'(): void {
+describe('Comment whitespace formatting tests', () => {
+  it('simple comment with no tags', () => {
     expect(parseCommentString('/** hello world */')).to.deep.eq(
       {
         summary: ['hello world'],
@@ -37,5 +35,5 @@ export class CommentWhitespaceTests {
       },
       'multi-line comment with blank lines',
     );
-  }
-}
+  });
+});

--- a/packages/comments/test/extended-tags.test.ts
+++ b/packages/comments/test/extended-tags.test.ts
@@ -1,11 +1,9 @@
 import { expect } from 'chai';
-import { suite, test } from 'mocha-typescript';
+import { describe, it } from 'mocha';
 import { parseCommentString } from '../src/index';
 
-@suite
-export class ExtendedTagsTests {
-  @test
-  public 'modifier tags'(): void {
+describe('Extended tags tests', () => {
+  it('modifier tags', () => {
     expect(
       parseCommentString(`
 /**
@@ -40,5 +38,5 @@ export class ExtendedTagsTests {
         },
       ],
     });
-  }
-}
+  });
+});

--- a/packages/comments/test/jsdoc-code-block.test.ts
+++ b/packages/comments/test/jsdoc-code-block.test.ts
@@ -1,11 +1,9 @@
 import { expect } from 'chai';
-import { suite, test } from 'mocha-typescript';
+import { describe, it } from 'mocha';
 import { parseCommentString } from '../src/index';
 
-@suite
-export class JSDocCodeBlockTests {
-  @test
-  public 'fenced code'(): void {
+describe('JSDoc code block tests', () => {
+  it('fenced code', () => {
     expect(
       parseCommentString(`
 /**
@@ -28,9 +26,8 @@ export class JSDocCodeBlockTests {
         },
       ],
     });
-  }
-  @test
-  public '@example tag'(): void {
+  });
+  it('@example tag', () => {
     expect(
       parseCommentString(`
 /**
@@ -53,9 +50,8 @@ export class JSDocCodeBlockTests {
         },
       ],
     });
-  }
-  @test
-  public '@doctest tag'(): void {
+  });
+  it('@doctest tag', () => {
     expect(
       parseCommentString(`
 /**
@@ -78,10 +74,9 @@ export class JSDocCodeBlockTests {
         },
       ],
     });
-  }
+  });
 
-  @test
-  public 'fenced code block in a docsection'(): void {
+  it('fenced code block in a docsection', () => {
     expect(
       parseCommentString(`/**
  * Concatenate two strings
@@ -105,5 +100,5 @@ export class JSDocCodeBlockTests {
         },
       ],
     });
-  }
-}
+  });
+});

--- a/packages/comments/test/jsdoc-params.test.ts
+++ b/packages/comments/test/jsdoc-params.test.ts
@@ -1,11 +1,9 @@
 import { expect } from 'chai';
-import { suite, test } from 'mocha-typescript';
+import { describe, it } from 'mocha';
 import { parseCommentString } from '../src/index';
 
-@suite
-export class JSDocParamsTests {
-  @test
-  public '@param tags (TS style)'(): void {
+describe('JSDoc params tests', () => {
+  it('@param tags (TS style)', () => {
     expect(
       parseCommentString(`
 /**
@@ -30,10 +28,9 @@ export class JSDocParamsTests {
       },
       'single-line comment',
     );
-  }
+  });
 
-  @test
-  public '@param tags (JS style) (1)'(): void {
+  it('@param tags (JS style) (1)', () => {
     expect(
       parseCommentString(`
 /**
@@ -57,10 +54,9 @@ export class JSDocParamsTests {
       },
       'single-line comment',
     );
-  }
+  });
 
-  @test
-  public '@param tags (JS style) (2)'(): void {
+  it('@param tags (JS style) (2)', () => {
     expect(
       parseCommentString(`
 /**
@@ -92,5 +88,5 @@ export class JSDocParamsTests {
       },
       'single-line comment',
     );
-  }
-}
+  });
+});

--- a/packages/comments/test/jsdoc-tags.test.ts
+++ b/packages/comments/test/jsdoc-tags.test.ts
@@ -1,11 +1,9 @@
 import { expect } from 'chai';
-import { suite, test } from 'mocha-typescript';
+import { describe, it } from 'mocha';
 import { parseCommentString } from '../src/index';
 
-@suite
-export class JSDocTagsTests {
-  @test
-  public '@returns tag'(): void {
+describe('JSDoc tags tests', () => {
+  it('@returns tag', () => {
     expect(
       parseCommentString(`
 /**
@@ -25,10 +23,9 @@ export class JSDocTagsTests {
         content: ['another thing', '\n', 'bar', '\n', '\n', 'third thing'],
       },
     });
-  }
+  });
 
-  @test
-  public '@deprecated'(): void {
+  it('@deprecated', () => {
     expect(
       parseCommentString(`
 /**
@@ -53,10 +50,9 @@ export class JSDocTagsTests {
       summary: ['This is only a comment in a file'],
       deprecated: ['until v99.0.0'],
     });
-  }
+  });
 
-  @test
-  public '@see'(): void {
+  it('@see', () => {
     expect(
       parseCommentString(`
 /**
@@ -75,5 +71,5 @@ export class JSDocTagsTests {
         },
       ],
     });
-  }
-}
+  });
+});

--- a/packages/comments/test/links.test.ts
+++ b/packages/comments/test/links.test.ts
@@ -1,11 +1,9 @@
 import { expect } from 'chai';
-import { suite, test } from 'mocha-typescript';
+import { describe, it } from 'mocha';
 import { parseCommentString } from '../src/index';
 
-@suite
-export class LinkTagsTests {
-  @test
-  public '{@link url}'(): void {
+describe('JSDoc link tag tests', () => {
+  it('{@link url}', () => {
     expect(
       parseCommentString(`
 /**
@@ -25,10 +23,9 @@ export class LinkTagsTests {
         },
       ],
     });
-  }
+  });
 
-  @test
-  public '{@link url | text}'(): void {
+  it('{@link url | text}', () => {
     expect(
       parseCommentString(`
 /**
@@ -48,5 +45,5 @@ export class LinkTagsTests {
         },
       ],
     });
-  }
-}
+  });
+});

--- a/packages/comments/test/mocha.opts
+++ b/packages/comments/test/mocha.opts
@@ -1,4 +1,3 @@
---ui mocha-typescript
 --require ts-node/register
 --require source-map-support/register
 --timeout 60000

--- a/packages/comments/test/public-api-surface.test.ts
+++ b/packages/comments/test/public-api-surface.test.ts
@@ -1,19 +1,16 @@
 import { expect } from 'chai';
-import { suite, test } from 'mocha-typescript';
+import { describe, it } from 'mocha';
 import * as Exported from '../src/index';
 
 const { parseCommentString, parser } = Exported;
 
-@suite
-export class PublicApiSurface {
-  @test
-  public 'public API surface is as expected'(): void {
+describe('Public API surface tests', () => {
+  it('public API surface is as expected', () => {
     expect(parseCommentString).to.be.a('function', 'parseCommentString is a function');
     expect(parser).to.be.a('object', 'parser is an object');
-  }
+  });
 
-  @test
-  public 'no extra exports'(): void {
+  it('no extra exports', () => {
     expect(Object.keys(Exported).sort()).to.eql(['parseCommentString', 'parser']);
-  }
-}
+  });
+});

--- a/packages/comments/test/tsdoc-tags.test.ts
+++ b/packages/comments/test/tsdoc-tags.test.ts
@@ -1,11 +1,9 @@
 import { expect } from 'chai';
-import { suite, test } from 'mocha-typescript';
+import { describe, it } from 'mocha';
 import { parseCommentString } from '../src/index';
 
-@suite
-export class TSDocTagsTests {
-  @test
-  public '@typeparam tags'(): void {
+describe('TSDoc tags tests', () => {
+  it('@typeparam tags', () => {
     expect(
       parseCommentString(`
 /**
@@ -25,10 +23,9 @@ export class TSDocTagsTests {
         },
       ],
     });
-  }
+  });
 
-  @test
-  public '@remarks'(): void {
+  it('@remarks', () => {
     expect(
       parseCommentString(`
 /**
@@ -50,10 +47,9 @@ export class TSDocTagsTests {
       summary: ['This is only a comment in a file'],
       remarks: ['This is my first line', '\n', '\n', 'another line', '\n', '\n', 'the last line'],
     });
-  }
+  });
 
-  @test
-  public 'modifier tags'(): void {
+  it('modifier tags', () => {
     expect(
       parseCommentString(`
 /**
@@ -67,5 +63,5 @@ export class TSDocTagsTests {
       summary: ['This is only a comment in a file', '\n', '\n', '\n', '\n', 'third thing'],
       modifiers: ['internal', 'beta'],
     });
-  }
-}
+  });
+});

--- a/packages/comments/test/util.test.ts
+++ b/packages/comments/test/util.test.ts
@@ -1,11 +1,9 @@
 import { expect } from 'chai';
-import { suite, test } from 'mocha-typescript';
+import { describe, it } from 'mocha';
 import { trimParagraphContent } from '../src/parse/utils';
 
-@suite
-export class CommentUtilTest {
-  @test
-  public async 'content array trimming'(): Promise<void> {
+describe('Comment utilities tests', () => {
+  it('content array trimming', async () => {
     expect(trimParagraphContent(['\n', '\n', 'foo', '\n', 'bar'])).to.deep.eq(['foo', '\n', 'bar']);
     expect(trimParagraphContent(['\n', '\n', 'foo', '\n', 'bar', '\n', '\n'])).to.deep.eq([
       'foo',
@@ -13,5 +11,5 @@ export class CommentUtilTest {
       'bar',
     ]);
     expect(trimParagraphContent(['foo', '\n', 'bar'])).to.deep.eq(['foo', '\n', 'bar']);
-  }
-}
+  });
+});

--- a/packages/core-linker/package.json
+++ b/packages/core-linker/package.json
@@ -41,7 +41,6 @@
     "eslint-plugin-import": "2.16.0",
     "eslint-plugin-prettier": "3.0.1",
     "mocha": "5.2.0",
-    "mocha-typescript": "1.1.17",
     "nyc": "13.3.0",
     "remark-cli": "6.0.1",
     "remark-lint": "6.0.4",

--- a/packages/core-linker/test/acceptance.test.ts
+++ b/packages/core-linker/test/acceptance.test.ts
@@ -1,12 +1,10 @@
 import { mapDict } from '@code-to-json/utils-ts';
 import { expect } from 'chai';
-import { suite, test } from 'mocha-typescript';
+import { describe, it } from 'mocha';
 import SingleFileAcceptanceTestCase from './helpers/test-case';
 
-@suite
-export class CoreLiknerAcceptanceTests {
-  @test
-  public async 'linking completes without error'(): Promise<void> {
+describe('Core linker acceptance tests', () => {
+  it('linking completes without error', async () => {
     const code = 'export let x: string[] = ["33"];';
     const t = new SingleFileAcceptanceTestCase(code);
     await t.run();
@@ -17,10 +15,9 @@ export class CoreLiknerAcceptanceTests {
       .to.contain('index');
     expect(file.symbol!.exports!.x!.name).to.eq('x');
     t.cleanup();
-  }
+  });
 
-  @test
-  public async 'linking a sampler of various symbols and types'(): Promise<void> {
+  it('linking a sampler of various symbols and types', async () => {
     const code = `export interface Foo<T> {
   bar: [T, string];
 }
@@ -76,5 +73,5 @@ export class Thing implements Foo<string> {
       otherThing: 'number[]',
     });
     t.cleanup();
-  }
-}
+  });
+});

--- a/packages/core-linker/test/mocha.opts
+++ b/packages/core-linker/test/mocha.opts
@@ -1,4 +1,3 @@
---ui mocha-typescript
 --require ts-node/register
 --require source-map-support/register
 --timeout 60000

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -43,7 +43,6 @@
     "eslint-plugin-import": "2.16.0",
     "eslint-plugin-prettier": "3.0.1",
     "mocha": "5.2.0",
-    "mocha-typescript": "1.1.17",
     "nyc": "13.3.0",
     "remark-cli": "6.0.1",
     "remark-lint": "6.0.4",

--- a/packages/core/test/acceptance/array.test.ts
+++ b/packages/core/test/acceptance/array.test.ts
@@ -1,12 +1,9 @@
 import { expect } from 'chai';
-import { slow, suite, test } from 'mocha-typescript';
+import { describe, it } from 'mocha';
 import SingleFileAcceptanceTestCase from './helpers/test-case';
 
-@suite
-@slow(800)
-export class ArraySerializationTests {
-  @test
-  public async 'export let x: string[] = ["33"];'(): Promise<void> {
+describe('Array serialization tests', () => {
+  it('export let x: string[] = ["33"];', async () => {
     const code = 'export let x: string[] = ["33"];';
     const t = new SingleFileAcceptanceTestCase(code);
     await t.run();
@@ -22,10 +19,9 @@ export class ArraySerializationTests {
     const arrayType = t.resolveReference(variableType.numberIndexType);
     expect(arrayType.text).to.eq('string');
     t.cleanup();
-  }
+  });
 
-  @test
-  public async 'export let x: [string, number, number]'(): Promise<void> {
+  it('export let x: [string, number, number]', async () => {
     const src = 'export let x: [string, number, number]';
     const t = new SingleFileAcceptanceTestCase(src);
     await t.run();
@@ -39,5 +35,5 @@ export class ArraySerializationTests {
     const arrayType = t.resolveReference(variableType.numberIndexType);
     expect(arrayType.text).to.eq('string | number');
     t.cleanup();
-  }
-}
+  });
+});

--- a/packages/core/test/acceptance/class.test.ts
+++ b/packages/core/test/acceptance/class.test.ts
@@ -1,15 +1,10 @@
 import { mapDict } from '@code-to-json/utils-ts';
 import { expect } from 'chai';
-import { slow, suite, test } from 'mocha-typescript';
+import { describe, it } from 'mocha';
 import SingleFileAcceptanceTestCase from './helpers/test-case';
 
-@suite
-@slow(800)
-export class ClassSerializationTests {
-  @test
-  public async 'class Vehicle { numWheels: number = 4; drive() { return "vroom";} }'(): Promise<
-    void
-  > {
+describe('Class serialization tests', () => {
+  it('class Vehicle { numWheels: number = 4; drive() { return "vroom";} }', async () => {
     const code = 'export class Vehicle { numWheels: number = 4; drive() { return "vroom";} }';
     const t = new SingleFileAcceptanceTestCase(code);
     await t.run();
@@ -41,14 +36,14 @@ export class ClassSerializationTests {
     expect(instanceType.text).to.eq('Vehicle');
     const instancePropNames = Object.keys(instanceType.properties!);
     expect(instancePropNames).to.deep.eq(['numWheels', 'drive']);
-    const props = instancePropNames.map((p) => t.resolveReference(instanceType.properties![p]));
+    const props = instancePropNames.map(p => t.resolveReference(instanceType.properties![p]));
     const [numWheelsSym, driveSym] = props;
     expect(numWheelsSym.flags).to.deep.eq(['Property']);
     expect(driveSym.flags).to.deep.eq(['Method', 'Transient']);
     expect(numWheelsSym.text).to.eq('numWheels');
     expect(driveSym.text).to.eq('drive');
 
-    const [numWheelsType, driveType] = props.map((s) => t.resolveReference(s.valueDeclarationType));
+    const [numWheelsType, driveType] = props.map(s => t.resolveReference(s.valueDeclarationType));
     expect(numWheelsType.text).to.eql('number');
     expect(driveType.text).to.eql('() => string');
     expect(numWheelsType.flags).to.deep.eq(['Number']);
@@ -56,12 +51,9 @@ export class ClassSerializationTests {
     expect(driveType.objectFlags).to.includes('Anonymous');
 
     t.cleanup();
-  }
+  });
 
-  @test
-  public async 'abstract class Vehicle { numWheels: number = 4; abstract drive(): string; }'(): Promise<
-    void
-  > {
+  it('abstract class Vehicle { numWheels: number = 4; abstract drive(): string; }', async () => {
     const code =
       'export abstract class Vehicle { numWheels: number = 4; abstract drive(): string; }';
     const t = new SingleFileAcceptanceTestCase(code);
@@ -89,7 +81,7 @@ export class ClassSerializationTests {
 
     const instancePropNames = Object.keys(classSymbolType.properties!);
     expect(instancePropNames).to.deep.eq(['numWheels', 'drive']);
-    const props = instancePropNames.map((p) => t.resolveReference(classSymbolType.properties![p]));
+    const props = instancePropNames.map(p => t.resolveReference(classSymbolType.properties![p]));
     const [numWheelsSym, driveSym] = props;
     expect(numWheelsSym.flags).to.deep.eq(['Property']);
     expect(driveSym.flags).to.deep.eq(['Method']);
@@ -98,10 +90,9 @@ export class ClassSerializationTests {
     expect(driveSym.isAbstract).to.eq(true);
 
     t.cleanup();
-  }
+  });
 
-  @test
-  public async 'class that inherits from nothing with implied constructor'(): Promise<void> {
+  it('class that inherits from nothing with implied constructor', async () => {
     const code = 'export class Vehicle { }';
     const t = new SingleFileAcceptanceTestCase(code);
     await t.run();
@@ -130,9 +121,9 @@ export class ClassSerializationTests {
     expect(constructorSig.text).to.eq('(): Vehicle');
 
     t.cleanup();
-  }
+  });
 
-  @test public async 'access modifier keyword on class method'(): Promise<void> {
+  it('access modifier keyword on class method', async () => {
     const code = `export class Foo {
       protected bar() {}
     }`;
@@ -140,19 +131,19 @@ export class ClassSerializationTests {
     await t.run();
     const file = t.sourceFile();
     const fileSymbol = t.resolveReference(file.symbol!);
-    const fileExports = mapDict(fileSymbol.exports!, (e) => t.resolveReference(e));
+    const fileExports = mapDict(fileSymbol.exports!, e => t.resolveReference(e));
     expect(Object.keys(fileExports)).to.deep.eq(['Foo']);
     const classSymbol = fileExports.Foo!;
 
     const instanceType = t.resolveReference(classSymbol.symbolType);
-    const instanceMembers = mapDict(instanceType.properties!, (p) => t.resolveReference(p));
+    const instanceMembers = mapDict(instanceType.properties!, p => t.resolveReference(p));
     const { bar } = instanceMembers;
     expect(bar!.modifiers).to.deep.include('protected');
 
     t.cleanup();
-  }
+  });
 
-  @test public async 'access modifier keyword via comment'(): Promise<void> {
+  it('access modifier keyword via comment', async () => {
     const code = `export class Foo {
       /**
        * @protected
@@ -163,20 +154,19 @@ export class ClassSerializationTests {
     await t.run();
     const file = t.sourceFile();
     const fileSymbol = t.resolveReference(file.symbol!);
-    const fileExports = mapDict(fileSymbol.exports!, (e) => t.resolveReference(e));
+    const fileExports = mapDict(fileSymbol.exports!, e => t.resolveReference(e));
     expect(Object.keys(fileExports)).to.deep.eq(['Foo']);
     const classSymbol = fileExports.Foo!;
 
     const instanceType = t.resolveReference(classSymbol.symbolType);
-    const instanceMembers = mapDict(instanceType.properties!, (p) => t.resolveReference(p));
+    const instanceMembers = mapDict(instanceType.properties!, p => t.resolveReference(p));
     const { bar } = instanceMembers;
     expect(bar!.modifiers).to.deep.include('protected');
 
     t.cleanup();
-  }
+  });
 
-  @test
-  public async 'inheriting a constructor from a base class'(): Promise<void> {
+  it('inheriting a constructor from a base class', async () => {
     const code = `class Vehicle {
   public readonly abc = 'def'
   constructor(n: number) { setTimeout(() => console.log('hello'), n)}
@@ -214,10 +204,9 @@ export class Car extends Vehicle {}`;
     expect(constructorSig.text).to.eq('(n: number): Car');
 
     t.cleanup();
-  }
+  });
 
-  @test
-  public async 'heritage clause serialization'(): Promise<void> {
+  it('heritage clause serialization', async () => {
     const code = `export interface HasVinNumber {
   vin: number;
 }
@@ -240,21 +229,24 @@ export class Car extends Vehicle implements HasVinNumber {
     const classSymbol = t.resolveReference(fileSymbol.exports!.Car);
 
     const classSymbolType = t.resolveReference(classSymbol.symbolType);
-    const baseTypes = classSymbolType.baseTypes!.map((bc) => t.resolveReference(bc));
-    expect(baseTypes.map((bt) => bt.text).join(', ')).to.eq('Vehicle');
+    const baseTypes = classSymbolType.baseTypes!.map(bc => t.resolveReference(bc));
+    expect(baseTypes.map(bt => bt.text).join(', ')).to.eq('Vehicle');
 
     const { heritageClauses } = classSymbol;
     expect(heritageClauses!.length).to.eq(2);
     expect(heritageClauses![0].kind).to.eq('extends');
-    expect(heritageClauses![0].types.map((typ) => t.resolveReference(typ).text).join(', ')).to.eq('Vehicle');
+    expect(heritageClauses![0].types.map(typ => t.resolveReference(typ).text).join(', ')).to.eq(
+      'Vehicle',
+    );
     expect(heritageClauses![1].kind).to.eq('implements');
-    expect(heritageClauses![1].types.map((typ) => t.resolveReference(typ).text).join(', ')).to.eq('HasVinNumber');
+    expect(heritageClauses![1].types.map(typ => t.resolveReference(typ).text).join(', ')).to.eq(
+      'HasVinNumber',
+    );
 
     t.cleanup();
-  }
+  });
 
-  @test
-  public async 'inheriting multiple constructor signatures from a base class'(): Promise<void> {
+  it('inheriting multiple constructor signatures from a base class', async () => {
     const code = `class Vehicle {
   public readonly abc = 'def'
 
@@ -296,10 +288,9 @@ export class Car extends Vehicle {}`;
     expect(constructorSig2.text).to.eq('(n: number, coeff: number): Car');
 
     t.cleanup();
-  }
+  });
 
-  @test
-  public async 'class with properties, methods and static functions'(): Promise<void> {
+  it('class with properties, methods and static functions', async () => {
     const code = `export class SimpleClass {
   constructor(bar: string) { console.log(bar); }
   public foo: string = 'bar';
@@ -330,7 +321,7 @@ export class Car extends Vehicle {}`;
 
     const classPropNames = Object.keys(classValueDeclarationType.properties!);
     expect(classPropNames).to.deep.eq(['hello', 'planet']);
-    const [helloSym, planetSym] = classPropNames.map((n) =>
+    const [helloSym, planetSym] = classPropNames.map(n =>
       t.resolveReference(classValueDeclarationType.properties![n]),
     );
     expect(helloSym.text).to.eq('hello');
@@ -346,22 +337,19 @@ export class Car extends Vehicle {}`;
     expect(instanceType.text).to.eq('SimpleClass');
     const instancePropNames = Object.keys(instanceType.properties!);
     expect(instancePropNames).to.deep.eq(['foo']);
-    const props = instancePropNames.map((p) => t.resolveReference(instanceType.properties![p]));
+    const props = instancePropNames.map(p => t.resolveReference(instanceType.properties![p]));
     const [fooSym] = props;
     expect(fooSym.flags).to.deep.eq(['Property']);
     expect(fooSym.text).to.eq('foo');
-    const [fooType] = props.map((s) => t.resolveReference(s.valueDeclarationType));
+    const [fooType] = props.map(s => t.resolveReference(s.valueDeclarationType));
 
     expect(fooType.text).to.eql('string');
     expect(fooType.flags).to.deep.eq(['String']);
 
     t.cleanup();
-  }
+  });
 
-  @test
-  public async 'class with properties, methods and static functions using a variety of access modifier keywords'(): Promise<
-    void
-  > {
+  it('class with properties, methods and static functions using a variety of access modifier keywords', async () => {
     const code = `export abstract class SimpleClass {
 
   protected static hello(): string { return 'world'; }
@@ -396,7 +384,7 @@ export class Car extends Vehicle {}`;
 
     const classPropNames = Object.keys(classValueDeclarationType.properties!);
     expect(classPropNames).to.deep.eq(['hello']);
-    const [helloSym] = classPropNames.map((n) =>
+    const [helloSym] = classPropNames.map(n =>
       t.resolveReference(classValueDeclarationType.properties![n]),
     );
     expect(helloSym.text).to.eq('hello');
@@ -410,11 +398,11 @@ export class Car extends Vehicle {}`;
     expect(instanceType.text).to.eq('SimpleClass');
     const instancePropNames = Object.keys(instanceType.properties!);
     expect(instancePropNames).to.deep.eq(['foo', 'myBar', 'myBaz']);
-    const props = instancePropNames.map((p) => t.resolveReference(instanceType.properties![p]));
+    const props = instancePropNames.map(p => t.resolveReference(instanceType.properties![p]));
     const [fooSym, myBarSym, myBazSym] = props;
     expect(fooSym.flags).to.deep.eq(['Property']);
     expect(fooSym.text).to.eq('foo');
-    const [fooType] = props.map((s) => t.resolveReference(s.valueDeclarationType));
+    const [fooType] = props.map(s => t.resolveReference(s.valueDeclarationType));
 
     expect(fooType.text).to.eql('string');
     expect(fooType.flags).to.deep.eq(['String']);
@@ -422,5 +410,5 @@ export class Car extends Vehicle {}`;
     expect(myBarSym.modifiers).to.deep.eq(['public']);
     expect(myBazSym.modifiers).to.deep.eq(['private']);
     t.cleanup();
-  }
-}
+  });
+});

--- a/packages/core/test/acceptance/comment.test.ts
+++ b/packages/core/test/acceptance/comment.test.ts
@@ -1,12 +1,9 @@
 import { expect } from 'chai';
-import { slow, suite, test } from 'mocha-typescript';
+import { describe, it } from 'mocha';
 import SingleFileAcceptanceTestCase from './helpers/test-case';
 
-@suite
-@slow(800)
-export class CommentSerializationTests {
-  @test
-  public async 'basic comments'(): Promise<void> {
+describe('Comment serialization tests', () => {
+  it('basic comments', async () => {
     const code = `interface Foo { num: number; }
 
     /**
@@ -28,10 +25,9 @@ export class CommentSerializationTests {
     expect(variableType.text).to.eql('Foo', 'has correct type');
 
     t.cleanup();
-  }
+  });
 
-  @test
-  public async 'with @see block tag'(): Promise<void> {
+  it('with @see block tag', async () => {
     const code = `interface Foo { num: number; }
 
     /**
@@ -62,10 +58,9 @@ export class CommentSerializationTests {
     expect(variableType.text).to.eql('Foo', 'has correct type');
 
     t.cleanup();
-  }
+  });
 
-  @test
-  public async 'with @param tags'(): Promise<void> {
+  it('with @param tags', async () => {
     const code = `interface Foo { num: number; }
 
     /**
@@ -104,17 +99,16 @@ export class CommentSerializationTests {
     expect(functionType.text).to.eql('(a: number, b: number) => number');
     const [callSig1] = functionType.callSignatures!;
     expect(callSig1.parameters!.length).to.eql(2);
-    const [sig1Param1, sig1Param2] = callSig1.parameters!.map((p) => t.resolveReference(p));
+    const [sig1Param1, sig1Param2] = callSig1.parameters!.map(p => t.resolveReference(p));
     expect(sig1Param1.jsDocTags![0].name).to.eq('param');
     expect(sig1Param2.jsDocTags![0].name).to.eq('param');
     expect(sig1Param1.jsDocTags![0].text).contains('first number');
     expect(sig1Param2.jsDocTags![0].text).contains('second number');
 
     t.cleanup();
-  }
+  });
 
-  @test
-  public async 'with an @example tag and fenced code example'(): Promise<void> {
+  it('with an @example tag and fenced code example', async () => {
     const code = `interface Foo { num: number; }
 
     /**
@@ -149,10 +143,9 @@ export class CommentSerializationTests {
       ],
     });
     t.cleanup();
-  }
+  });
 
-  @test
-  public async 'with inline code'(): Promise<void> {
+  it('with inline code', async () => {
     const code = `interface Foo { num: number; }
 
     /**
@@ -179,10 +172,9 @@ export class CommentSerializationTests {
       ],
     });
     t.cleanup();
-  }
+  });
 
-  @test
-  public async 'with HTML tags'(): Promise<void> {
+  it('with HTML tags', async () => {
     const code = `interface Foo { num: number; }
 
     /**
@@ -245,5 +237,5 @@ export class CommentSerializationTests {
       ],
     });
     t.cleanup();
-  }
-}
+  });
+});

--- a/packages/core/test/acceptance/functions.test.ts
+++ b/packages/core/test/acceptance/functions.test.ts
@@ -1,12 +1,9 @@
 import { expect } from 'chai';
-import { slow, suite, test } from 'mocha-typescript';
+import { describe, it } from 'mocha';
 import SingleFileAcceptanceTestCase from './helpers/test-case';
 
-@suite
-@slow(800)
-export class FunctionAnalysisTests {
-  @test
-  public async 'zero-argument function'(): Promise<void> {
+describe('Function serialization tests', () => {
+  it('zero-argument function', async () => {
     const code = "export function foo() { return 'bar'; }";
     const t = new SingleFileAcceptanceTestCase(code);
     await t.run();
@@ -30,10 +27,9 @@ export class FunctionAnalysisTests {
     expect(returnType.text).to.eq('string');
 
     t.cleanup();
-  }
+  });
 
-  @test
-  public async 'function w/ rest param'(): Promise<void> {
+  it('function w/ rest param', async () => {
     const code = "export function foo(...parts: string[]) { return parts.join(', '); }";
     const t = new SingleFileAcceptanceTestCase(code);
     await t.run();
@@ -60,10 +56,9 @@ export class FunctionAnalysisTests {
     expect(returnType.text).to.eq('string');
 
     t.cleanup();
-  }
+  });
 
-  @test
-  public async 'unary function'(): Promise<void> {
+  it('unary function', async () => {
     const code = 'export function foo(str: string) { return str.toUpperCase(); }';
     const t = new SingleFileAcceptanceTestCase(code);
     await t.run();
@@ -90,10 +85,9 @@ export class FunctionAnalysisTests {
     expect(returnType.text).to.eq('string');
 
     t.cleanup();
-  }
+  });
 
-  @test
-  public async 'function with multiple signatures'(): Promise<void> {
+  it('function with multiple signatures', async () => {
     const code = `
     export function adder(a: string, b: string): string;
     export function adder(a: number, b: number): number;
@@ -145,5 +139,5 @@ export class FunctionAnalysisTests {
     expect(sig2ReturnType.text).to.eq('number');
 
     t.cleanup();
-  }
-}
+  });
+});

--- a/packages/core/test/acceptance/interface.test.ts
+++ b/packages/core/test/acceptance/interface.test.ts
@@ -1,12 +1,9 @@
 import { expect } from 'chai';
-import { slow, suite, test } from 'mocha-typescript';
+import { describe, it } from 'mocha';
 import SingleFileAcceptanceTestCase from './helpers/test-case';
 
-@suite
-@slow(800)
-export class InterfaceSerializationTests {
-  @test
-  public async 'non-exported interface'(): Promise<void> {
+describe('Interface serialization tests', () => {
+  it('non-exported interface', async () => {
     const code = `interface Foo { num: number; }
 
     export const x: Foo = { num: 4 };`;
@@ -29,10 +26,9 @@ export class InterfaceSerializationTests {
     const firstPropType = t.resolveReference(firstProp.valueDeclarationType);
     expect(firstPropType.text).to.eql('number');
     t.cleanup();
-  }
+  });
 
-  @test
-  public async 'interface Foo {bar: number; readonly baz: Promise<string>}'(): Promise<void> {
+  it('interface Foo {bar: number; readonly baz: Promise<string>}', async () => {
     const code = `export interface Foo {bar: number; readonly baz: Promise<string>}`;
     const t = new SingleFileAcceptanceTestCase(code);
     await t.run();
@@ -49,10 +45,10 @@ export class InterfaceSerializationTests {
     expect(interfaceType.objectFlags).to.deep.eq(['Interface']);
     const typePropertyNames = Object.keys(interfaceType.properties!);
     expect(typePropertyNames).to.deep.eq(['bar', 'baz']);
-    const [bar, baz] = Object.keys(interfaceType.properties!).map((pName) =>
+    const [bar, baz] = Object.keys(interfaceType.properties!).map(pName =>
       t.resolveReference(interfaceType.properties![pName]),
     );
-    const [barType, bazType] = [bar, baz].map((s) => t.resolveReference(s.valueDeclarationType));
+    const [barType, bazType] = [bar, baz].map(s => t.resolveReference(s.valueDeclarationType));
     expect(bar.name).to.eql('bar');
     expect(barType.text).to.eql('number');
     expect(bar.modifiers).to.deep.eq(undefined);
@@ -60,5 +56,5 @@ export class InterfaceSerializationTests {
     expect(bazType.text).to.eql('Promise<string>');
     expect(baz.modifiers).to.deep.eq(['readonly']);
     t.cleanup();
-  }
-}
+  });
+});

--- a/packages/core/test/acceptance/serialization-boundary.test.ts
+++ b/packages/core/test/acceptance/serialization-boundary.test.ts
@@ -1,13 +1,9 @@
-
 import { expect } from 'chai';
-import { slow, suite, test } from 'mocha-typescript';
+import { describe, it } from 'mocha';
 import SingleFileAcceptanceTestCase from './helpers/test-case';
 
-@suite
-@slow(800)
-export class SerializationBoundaryTests {
-  @test
-  public async 'array members should not be serialized - string[]'(): Promise<void> {
+describe('Serializatino boundary tests', () => {
+  it('array members should not be serialized - string[]', async () => {
     const code = `export let x = ['a', 'b', 'c']`;
     const t = new SingleFileAcceptanceTestCase(code);
     await t.run();
@@ -19,7 +15,7 @@ export class SerializationBoundaryTests {
     const varType = t.resolveReference(varSymbol.valueDeclarationType);
 
     const { allTypes, allSymbols } = t;
-    const allSerializedTypeNames = Object.keys(allTypes).map((tid) => allTypes[tid]!.text);
+    const allSerializedTypeNames = Object.keys(allTypes).map(tid => allTypes[tid]!.text);
 
     expect(allSerializedTypeNames).to.include.deep.members([
       'string[]',
@@ -30,7 +26,7 @@ export class SerializationBoundaryTests {
     ]);
     expect(allSerializedTypeNames).to.not.include.deep.members(['indexOf']);
 
-    const allSerializedSymbolNames = Object.keys(allSymbols).map((tid) => allSymbols[tid]!.text);
+    const allSerializedSymbolNames = Object.keys(allSymbols).map(tid => allSymbols[tid]!.text);
 
     expect(allSerializedSymbolNames).to.include.deep.members([
       'x',
@@ -42,10 +38,9 @@ export class SerializationBoundaryTests {
     expect(varType.text).to.eql('string[]');
     expect(varType.flags).to.deep.eq(['Object']);
     t.cleanup();
-  }
+  });
 
-  @test
-  public async 'promise should not be serialized - explicit Promise<number>'(): Promise<void> {
+  it('promise should not be serialized - explicit Promise<number>', async () => {
     const code = `export const x: Promise<number> = Promise.resolve(4)`;
     const t = new SingleFileAcceptanceTestCase(code);
     await t.run();
@@ -58,11 +53,11 @@ export class SerializationBoundaryTests {
     const varType = t.resolveReference(varSymbol.valueDeclarationType);
 
     const { allTypes, allSymbols } = t;
-    const allSerializedTypeNames = Object.keys(allTypes).map((tid) => allTypes[tid]!.text);
+    const allSerializedTypeNames = Object.keys(allTypes).map(tid => allTypes[tid]!.text);
 
     expect(allSerializedTypeNames).to.include.deep.members(['Promise<number>', 'Promise<T>']);
 
-    const allSerializedSymbolNames = Object.keys(allSymbols).map((tid) => allSymbols[tid]!.text);
+    const allSerializedSymbolNames = Object.keys(allSymbols).map(tid => allSymbols[tid]!.text);
 
     expect(allSerializedSymbolNames).to.include.deep.members([
       'x',
@@ -73,10 +68,9 @@ export class SerializationBoundaryTests {
     expect(varType.text).to.eql('Promise<number>');
     expect(varType.flags).to.deep.eq(['Object']);
     t.cleanup();
-  }
+  });
 
-  @test
-  public async 'promise should not be serialized - implicit Promise<number>'(): Promise<void> {
+  it('promise should not be serialized - implicit Promise<number>', async () => {
     const code = `export const x = Promise.resolve(4)`;
     const t = new SingleFileAcceptanceTestCase(code);
     await t.run();
@@ -89,11 +83,11 @@ export class SerializationBoundaryTests {
     const varType = t.resolveReference(varSymbol.valueDeclarationType);
 
     const { allTypes, allSymbols } = t;
-    const allSerializedTypeNames = Object.keys(allTypes).map((tid) => allTypes[tid]!.text);
+    const allSerializedTypeNames = Object.keys(allTypes).map(tid => allTypes[tid]!.text);
 
     expect(allSerializedTypeNames).to.contain.deep.members(['Promise<number>', 'Promise<T>']);
 
-    const allSerializedSymbolNames = Object.keys(allSymbols).map((tid) => allSymbols[tid]!.text);
+    const allSerializedSymbolNames = Object.keys(allSymbols).map(tid => allSymbols[tid]!.text);
 
     expect(allSerializedSymbolNames).to.include.deep.members([
       'x',
@@ -104,5 +98,5 @@ export class SerializationBoundaryTests {
     expect(varType.text).to.eql('Promise<number>');
     expect(varType.flags).to.deep.eq(['Object']);
     t.cleanup();
-  }
-}
+  });
+});

--- a/packages/core/test/acceptance/signatutre.test.ts
+++ b/packages/core/test/acceptance/signatutre.test.ts
@@ -1,13 +1,10 @@
 import { isDefined } from '@code-to-json/utils';
 import { expect } from 'chai';
-import { slow, suite, test } from 'mocha-typescript';
+import { describe, it } from 'mocha';
 import SingleFileAcceptanceTestCase from './helpers/test-case';
 
-@suite
-@slow(800)
-export class SignatureSerializationTests {
-  @test
-  public async 'function with one signature'(): Promise<void> {
+describe('Signature serialization tests', () => {
+  it('function with one signature', async () => {
     const code = `export function add(a: number, b: number) { return a + b; }`;
     const t = new SingleFileAcceptanceTestCase(code);
     await t.run();
@@ -41,10 +38,9 @@ export class SignatureSerializationTests {
       },
     ]);
     t.cleanup();
-  }
+  });
 
-  @test
-  public async 'param and return types via JSDoc comment'(): Promise<void> {
+  it('param and return types via JSDoc comment', async () => {
     const code = `/**
  * @param a {string} first thing
  * @param b {string} second thing
@@ -83,10 +79,9 @@ export function add(a, b) { return a + b; }`;
       },
     ]);
     t.cleanup();
-  }
+  });
 
-  @test
-  public async 'function with multiple signatures'(): Promise<void> {
+  it('function with multiple signatures', async () => {
     const code = `export function add(a: string, b: string): string;
 export function add(a: number, b: number): number;
 export function add(a: number | string, b: number | string): number | string {
@@ -152,10 +147,9 @@ export function add(a: number | string, b: number | string): number | string {
     ]);
 
     t.cleanup();
-  }
+  });
 
-  @test
-  public async 'function with multiple signatures, sharing documentation'(): Promise<void> {
+  it('function with multiple signatures, sharing documentation', async () => {
     const code = `
 /**
  * Add a couple of things together
@@ -240,12 +234,9 @@ export function add(a: number | string, b: number | string): number | string {
     });
     expect(fnType.callSignatures![1].documentation).to.eq(undefined);
     t.cleanup();
-  }
+  });
 
-  @test
-  public async 'function with multiple signatures, with a doc override for several signatures'(): Promise<
-    void
-  > {
+  it('function with multiple signatures, with a doc override for several signatures', async () => {
     const code = `
 /**
  * Add a couple of strings together
@@ -360,5 +351,5 @@ export function add(a: number | string, b: number | string): number | string {
       summary: ['Add a couple of numbers together'],
     });
     t.cleanup();
-  }
-}
+  });
+});

--- a/packages/core/test/acceptance/types.test.ts
+++ b/packages/core/test/acceptance/types.test.ts
@@ -1,13 +1,9 @@
-
 import { expect } from 'chai';
-import { slow, suite, test } from 'mocha-typescript';
+import { describe, it } from 'mocha';
 import SingleFileAcceptanceTestCase from './helpers/test-case';
 
-@suite
-@slow(800)
-export class TypeSerializationTests {
-  @test
-  public async 'type queries'(): Promise<void> {
+describe('Type serialization tests', () => {
+  it('type queries', async () => {
     const code = `let rectangle1 = { width: 100, height: 200 };
     export let x: typeof rectangle1;`;
     const t = new SingleFileAcceptanceTestCase(code);
@@ -22,10 +18,9 @@ export class TypeSerializationTests {
     expect(typeType.text).to.eql('{ width: number; height: number; }');
     expect(typeType.flags).to.deep.eq(['Object']);
     t.cleanup();
-  }
+  });
 
-  @test
-  public async 'type Dict<T> = { [k: string]: T | undefined }'(): Promise<void> {
+  it('type Dict<T> = { [k: string]: T | undefined }', async () => {
     const code = `export type Dict<T> = { [k: string]: T | undefined }`;
     const t = new SingleFileAcceptanceTestCase(code);
     await t.run();
@@ -45,9 +40,8 @@ export class TypeSerializationTests {
     // TODO: this should really be T | undefined, although it's coming through as T
     expect(stringIndexType.text).to.include('T');
     t.cleanup();
-  }
-  @test
-  public async 'with comments'(): Promise<void> {
+  });
+  it('with comments', async () => {
     const code = `/**
  * A dictionary
  */
@@ -62,10 +56,9 @@ export type Dict<T> = { [k: string]: T | undefined }`;
     expect(typeSymbol.documentation).to.deep.eq({ summary: ['A dictionary'] }, 'Documentation');
 
     t.cleanup();
-  }
+  });
 
-  @test
-  public async 'type Dict<T extends "foo"|"bar"|"baz"> = { [k: string]: T }'(): Promise<void> {
+  it('type Dict<T extends "foo"|"bar"|"baz"> = { [k: string]: T }', async () => {
     const code = `export type Dict<T extends "foo"|"bar"|"baz"> = { [k: string]: T }`;
     const t = new SingleFileAcceptanceTestCase(code);
     await t.run();
@@ -84,10 +77,9 @@ export type Dict<T> = { [k: string]: T | undefined }`;
     const stringIndexType = t.resolveReference(typeType.stringIndexType);
     expect(stringIndexType.text).to.include('T');
     t.cleanup();
-  }
+  });
 
-  @test
-  public async 'type StringNumberOrBoolean = string | number | true'(): Promise<void> {
+  it('type StringNumberOrBoolean = string | number | true', async () => {
     const code = `export type StringNumberOrBoolean = string | number | true`;
     const t = new SingleFileAcceptanceTestCase(code);
     await t.run();
@@ -114,10 +106,9 @@ export type Dict<T> = { [k: string]: T | undefined }`;
     expect(r.flags).to.deep.eq(['BooleanLiteral']);
 
     t.cleanup();
-  }
+  });
 
-  @test
-  public async 'type Split = typeof String.prototype.split'(): Promise<void> {
+  it('type Split = typeof String.prototype.split', async () => {
     const code = `export type Split = typeof String.prototype.split`;
     const t = new SingleFileAcceptanceTestCase(code);
     await t.run();
@@ -134,5 +125,5 @@ export type Dict<T> = { [k: string]: T | undefined }`;
     expect(!!typeType.typeParameters).to.eq(false);
 
     t.cleanup();
-  }
-}
+  });
+});

--- a/packages/core/test/acceptance/variable.test.ts
+++ b/packages/core/test/acceptance/variable.test.ts
@@ -1,12 +1,9 @@
 import { expect } from 'chai';
-import { slow, suite, test } from 'mocha-typescript';
+import { describe, it } from 'mocha';
 import SingleFileAcceptanceTestCase from './helpers/test-case';
 
-@suite
-@slow(800)
-export class VariableSerializationTests {
-  @test
-  public async 'export const x: number = 1;'(): Promise<void> {
+describe('Variable serialization tests', () => {
+  it('export const x: number = 1;', async () => {
     const code = 'export const x: number = 1;';
     const t = new SingleFileAcceptanceTestCase(code);
     await t.run();
@@ -24,10 +21,9 @@ export class VariableSerializationTests {
     expect(variableType.text).to.eql('number');
     expect(variableType.flags).to.deep.eq(['Number']);
     t.cleanup();
-  }
+  });
 
-  @test
-  public async 'export const x = 1;'(): Promise<void> {
+  it('export const x = 1;', async () => {
     const code = 'export const x = 1;';
     const t = new SingleFileAcceptanceTestCase(code);
     await t.run();
@@ -42,10 +38,9 @@ export class VariableSerializationTests {
     expect(variableType.text).to.eql('1');
     expect(variableType.flags).to.deep.eq(['NumberLiteral']);
     t.cleanup();
-  }
+  });
 
-  @test
-  public async 'export let x = 1;'(): Promise<void> {
+  it('export let x = 1;', async () => {
     const code = 'export let x = 1;';
     const t = new SingleFileAcceptanceTestCase(code);
     await t.run();
@@ -59,10 +54,9 @@ export class VariableSerializationTests {
     expect(variableType.text).to.eql('number');
     expect(variableType.flags).to.deep.eq(['Number']);
     t.cleanup();
-  }
+  });
 
-  @test
-  public async 'export let x: string | number = 33;'(): Promise<void> {
+  it('export let x: string | number = 33;', async () => {
     const src = 'export let x: string | number = 33;';
     const t = new SingleFileAcceptanceTestCase(src);
     await t.run();
@@ -76,10 +70,9 @@ export class VariableSerializationTests {
     expect(variableType.text).to.eql('string | number');
     expect(variableType.flags).to.deep.eq(['Union']);
     t.cleanup();
-  }
+  });
 
-  @test
-  public async 'export const x: Promise<number> = Promise.resolve(4);'(): Promise<void> {
+  it('export const x: Promise<number> = Promise.resolve(4);', async () => {
     const code = 'export const x: Promise<number> = Promise.resolve(4);';
     const t = new SingleFileAcceptanceTestCase(code);
     await t.run();
@@ -95,12 +88,9 @@ export class VariableSerializationTests {
     expect(variableType.libName).to.eq('lib.es2015.promise.d.ts');
     expect(variableType.objectFlags).to.deep.eq(['Reference']);
     t.cleanup();
-  }
+  });
 
-  @test
-  public async 'export const x: { p: Promise<number[]> } = { p: Promise.resolve([1, 2, 3]) };'(): Promise<
-    void
-  > {
+  it('export const x: { p: Promise<number[]> } = { p: Promise.resolve([1, 2, 3]) };', async () => {
     const code = 'export const x: { p: Promise<number[]> } = { p: Promise.resolve([1, 2, 3]) };';
     const t = new SingleFileAcceptanceTestCase(code);
     await t.run();
@@ -125,10 +115,9 @@ export class VariableSerializationTests {
     expect(pTyp.text).to.eq('Promise<number[]>');
     expect(pTyp.libName).to.eq('lib.es2015.promise.d.ts');
     t.cleanup();
-  }
+  });
 
-  @test
-  public async "export const x: Pick<Promise<number>, 'then'>"(): Promise<void> {
+  it("export const x: Pick<Promise<number>, 'then'>", async () => {
     const code = "export const x: Pick<Promise<number>, 'then'>";
     const t = new SingleFileAcceptanceTestCase(code);
     await t.run();
@@ -144,5 +133,5 @@ export class VariableSerializationTests {
     expect(variableType.objectFlags).to.deep.eq(['Mapped', 'Instantiated']);
 
     t.cleanup();
-  }
-}
+  });
+});

--- a/packages/core/test/mocha.opts
+++ b/packages/core/test/mocha.opts
@@ -1,4 +1,3 @@
---ui mocha-typescript
 --require ts-node/register
 --require source-map-support/register
 --timeout 60000

--- a/packages/core/test/serializers/amd-dependency.test.ts
+++ b/packages/core/test/serializers/amd-dependency.test.ts
@@ -1,13 +1,11 @@
 import { expect } from 'chai';
-import { suite, test } from 'mocha-typescript';
+import { describe, it } from 'mocha';
 import serializeAmdDependency from '../../src/serializers/amd-dependency';
 
-@suite
-export class AMDDependencySerializationTests {
-  @test
-  public async 'basic tests'(): Promise<void> {
+describe('AMD dependency serialization tests', () => {
+  it('basic tests', async () => {
     const serialized = serializeAmdDependency({ name: 'foo', path: 'bar' });
     expect(serialized).to.have.property('path', 'bar');
     expect(serialized).to.have.property('name', 'foo');
-  }
-}
+  });
+});

--- a/packages/core/test/serializers/source-file.test.ts
+++ b/packages/core/test/serializers/source-file.test.ts
@@ -1,17 +1,15 @@
 import { createRef } from '@code-to-json/utils';
 import { createIdGenerator } from '@code-to-json/utils-ts';
 import { expect } from 'chai';
-import { suite, test } from 'mocha-typescript';
+import { describe, it } from 'mocha';
 import * as ts from 'typescript';
 import { RefRegistry, SymbolRef } from '../../src';
 import serializeSourceFile from '../../src/serializers/source-file';
 import serializeSymbol from '../../src/serializers/symbol';
 import { setupScenario } from './helpers';
 
-@suite
-export class SourceFileSerializtionTests {
-  @test
-  public async 'single-function, no exports'(): Promise<void> {
+describe('SourceFile serialization tests', () => {
+  it('single-function, no exports', async () => {
     const { checker, sf, collector } = setupScenario(
       `function add(a: number, b: number): number { return a + b; }
 const x = add(4, 5);
@@ -36,10 +34,9 @@ console.log(x);`,
       id: 'F01m4wncyo0ry',
       isDeclarationFile: false,
     });
-  }
+  });
 
-  @test
-  public async 'single exported function'(): Promise<void> {
+  it('single exported function', async () => {
     const { checker, sf, collector } = setupScenario(
       `export function add(a: number, b: number): number { return a + b; }`,
     );
@@ -95,5 +92,5 @@ console.log(x);`,
       .to.haveOwnProperty('valueDeclarationType')
       .instanceOf(Array)
       .lengthOf(2);
-  }
-}
+  });
+});

--- a/packages/core/test/serializers/symbol.test.ts
+++ b/packages/core/test/serializers/symbol.test.ts
@@ -1,16 +1,14 @@
 import { createRef } from '@code-to-json/utils';
 import { createIdGenerator } from '@code-to-json/utils-ts';
 import { expect } from 'chai';
-import { suite, test } from 'mocha-typescript';
+import { describe, it } from 'mocha';
 import * as ts from 'typescript';
 import { RefRegistry, SourceFileRef } from '../../src';
 import serializeSourceFile from '../../src/serializers/source-file';
 import { setupScenario } from './helpers';
 
-@suite
-export class SymbolSerializtionTests {
-  @test
-  public async 'Function signature'(): Promise<void> {
+describe('Symbol serialization tests', () => {
+  it('Function signature', async () => {
     const { checker, sf, collector } = setupScenario(
       'function add(a: number, b: number): number { return a + b; }',
     );
@@ -35,5 +33,5 @@ export class SymbolSerializtionTests {
       originalFileName: 'module.ts',
       pathInPackage: 'module',
     });
-  }
-}
+  });
+});

--- a/packages/core/test/simple-js-program.test.ts
+++ b/packages/core/test/simple-js-program.test.ts
@@ -1,7 +1,7 @@
 import { setupTestCase } from '@code-to-json/test-helpers';
 import { createProgramFromCodeString } from '@code-to-json/utils-ts';
 import { expect } from 'chai';
-import { slow, suite, test } from 'mocha-typescript';
+import { describe, it } from 'mocha';
 import * as path from 'path';
 import { getDeclarationFiles } from './test-helpers';
 
@@ -42,11 +42,8 @@ const STANDARD_LIBS = [
   'lib.esnext.full.d.ts',
 ];
 
-@suite
-@slow(800)
-export class TypeScriptFixturePrograms {
-  @test
-  public async 'creation of a simple JS program from fixture files'(): Promise<void> {
+describe('TypeScript fixture program tests', () => {
+  it('creation of a simple JS program from fixture files', async () => {
     const { program } = await setupTestCase(
       path.join(__dirname, '..', '..', '..', 'samples', 'js-single-file'),
       ['src/index.js'],
@@ -60,10 +57,9 @@ export class TypeScriptFixturePrograms {
     expect(nonDeclarationFiles[0].fileName)
       .to.contain('src')
       .to.contain('index.js');
-  }
+  });
 
-  @test
-  public async 'creation of a simple JS program from fixture object'(): Promise<void> {
+  it('creation of a simple JS program from fixture object', async () => {
     const { program } = await setupTestCase(
       {
         'tsconfig.json': `{
@@ -75,7 +71,7 @@ export class TypeScriptFixturePrograms {
     "include": ["**/*.test.ts", "../src/**/*.ts"]
   }
 `,
-        "src": {
+        src: {
           'index.js': `import { readdirSync } from 'fs';
 
 /**
@@ -156,10 +152,9 @@ export class Unicycle extends Vehicle {
     expect(nonDeclarationFiles[0].fileName)
       .to.contain('src')
       .to.contain('index.js');
-  }
+  });
 
-  @test
-  public async 'creation of a simple TS program from string'(): Promise<void> {
+  it('creation of a simple TS program from string', async () => {
     const { program } = createProgramFromCodeString("export const x: string = 'foo';", 'ts');
     const { tsLibNames, nonDeclarationFiles } = getDeclarationFiles(program.getSourceFiles());
 
@@ -170,5 +165,5 @@ export class Unicycle extends Vehicle {
     expect(nonDeclarationFiles[0].fileName)
       .and.to.contain('module.ts')
       .but.not.contain('src');
-  }
-}
+  });
+});

--- a/packages/formatter-linker/package.json
+++ b/packages/formatter-linker/package.json
@@ -41,7 +41,6 @@
     "eslint-plugin-import": "2.16.0",
     "eslint-plugin-prettier": "3.0.1",
     "mocha": "5.2.0",
-    "mocha-typescript": "1.1.17",
     "nyc": "13.3.0",
     "remark-cli": "6.0.1",
     "remark-lint": "6.0.4",

--- a/packages/formatter-linker/test/acceptance.test.ts
+++ b/packages/formatter-linker/test/acceptance.test.ts
@@ -1,12 +1,10 @@
 import { mapDict } from '@code-to-json/utils-ts';
 import { expect } from 'chai';
-import { suite, test } from 'mocha-typescript';
+import { describe, it } from 'mocha';
 import SingleFileAcceptanceTestCase from './helpers/test-case';
 
-@suite
-export class FormatterLinkerAcceptanceTests {
-  @test
-  public async 'linking completes without error'(): Promise<void> {
+describe('Formatter linker acceptance tests', () => {
+  it('linking completes without error', async () => {
     const code = 'export let x: string[] = ["33"];';
     const t = new SingleFileAcceptanceTestCase(code);
     await t.run();
@@ -17,10 +15,9 @@ export class FormatterLinkerAcceptanceTests {
       .to.contain('index');
     expect(file.symbol!.exports!.x!.name).to.eq('x');
     t.cleanup();
-  }
+  });
 
-  @test
-  public async 'linking a sampler of various symbols and types'(): Promise<void> {
+  it('linking a sampler of various symbols and types', async () => {
     const code = `export interface Foo<T> {
   bar: [T, string];
 }
@@ -57,7 +54,7 @@ export class Thing implements Foo<string> {
     expect(file.symbol!.exports!.Thing!.heritageClauses![0].kind).to.eq('implements');
     expect(file.symbol!.exports!.Thing!.heritageClauses![0].types[0].text).to.eq('Foo<string>');
     expect(
-      mapDict(file.symbol!.exports!.Thing!.type!.properties!, (p) => p.valueType!.text),
+      mapDict(file.symbol!.exports!.Thing!.type!.properties!, p => p.valueType!.text),
     ).to.deep.eq({
       bar: '[string, string]',
       go: '() => Promise<string>',
@@ -65,5 +62,5 @@ export class Thing implements Foo<string> {
       otherThing: 'number[]',
     });
     t.cleanup();
-  }
-}
+  });
+});

--- a/packages/formatter-linker/test/mocha.opts
+++ b/packages/formatter-linker/test/mocha.opts
@@ -1,4 +1,3 @@
---ui mocha-typescript
 --require ts-node/register
 --require source-map-support/register
 --timeout 60000

--- a/packages/formatter/package.json
+++ b/packages/formatter/package.json
@@ -36,7 +36,6 @@
     "eslint-plugin-import": "2.16.0",
     "eslint-plugin-prettier": "3.0.1",
     "mocha": "5.2.0",
-    "mocha-typescript": "1.1.17",
     "nyc": "13.3.0",
     "remark-cli": "6.0.1",
     "remark-lint": "6.0.4",

--- a/packages/formatter/test/acceptance/classes.test.ts
+++ b/packages/formatter/test/acceptance/classes.test.ts
@@ -1,18 +1,16 @@
 import { mapDict } from '@code-to-json/utils-ts';
 import { expect } from 'chai';
-import { slow, suite, test } from 'mocha-typescript';
+import { describe, it } from 'mocha';
 import SingleFileAcceptanceTestCase from './helpers/test-case';
 
-@suite
-@slow(800)
-export class ClassFormatterAcceptanceTests {
-  @test public async 'simple class'(): Promise<void> {
+describe('Class formatter acceptance tests', () => {
+  it('simple class', async () => {
     const code = `export class Foo{}`;
     const t = new SingleFileAcceptanceTestCase(code);
     await t.run();
     const file = t.sourceFile();
     const fileSymbol = t.resolveReference(file.symbol!);
-    const fileExports = mapDict(fileSymbol.exports!, (e) => t.resolveReference(e));
+    const fileExports = mapDict(fileSymbol.exports!, e => t.resolveReference(e));
     expect(Object.keys(fileExports)).to.deep.eq(['Foo']);
     const classSymbol = fileExports.Foo!;
     expect(classSymbol.name).to.eq('Foo');
@@ -28,15 +26,15 @@ export class ClassFormatterAcceptanceTests {
     const instanceType = t.resolveReference(classSymbol.type);
     expect(instanceType.text).to.eql('Foo');
     t.cleanup();
-  }
+  });
 
-  @test public async 'simple class (default export)'(): Promise<void> {
+  it('simple class (default export)', async () => {
     const code = `export default class Foo{}`;
     const t = new SingleFileAcceptanceTestCase(code);
     await t.run();
     const file = t.sourceFile();
     const fileSymbol = t.resolveReference(file.symbol!);
-    const fileExports = mapDict(fileSymbol.exports!, (e) => t.resolveReference(e));
+    const fileExports = mapDict(fileSymbol.exports!, e => t.resolveReference(e));
     expect(Object.keys(fileExports)).to.deep.eq(['default']);
     const classSymbol = fileExports.default!;
     expect(classSymbol.name).to.eq('default');
@@ -51,9 +49,9 @@ export class ClassFormatterAcceptanceTests {
     expect(classType.constructorSignatures!.length).to.eq(1);
     expect(t.resolveReference(classSymbol.type).text).to.eql('Foo');
     t.cleanup();
-  }
+  });
 
-  @test public async 'class with methods'(): Promise<void> {
+  it('class with methods', async () => {
     const code = `export class Foo {
       bar() { return '--bar--'; }
       baz() { return '--baz--'; }
@@ -62,7 +60,7 @@ export class ClassFormatterAcceptanceTests {
     await t.run();
     const file = t.sourceFile();
     const fileSymbol = t.resolveReference(file.symbol!);
-    const fileExports = mapDict(fileSymbol.exports!, (e) => t.resolveReference(e));
+    const fileExports = mapDict(fileSymbol.exports!, e => t.resolveReference(e));
     expect(Object.keys(fileExports)).to.deep.eq(['Foo']);
     const classSymbol = fileExports.Foo!;
     expect(classSymbol.name).to.eq('Foo');
@@ -78,7 +76,7 @@ export class ClassFormatterAcceptanceTests {
     expect(classType.constructorSignatures!.length).to.eq(1);
     const instanceType = t.resolveReference(classSymbol.type);
     expect(instanceType.text).to.eql('Foo');
-    const instanceMembers = mapDict(instanceType.properties!, (p) => t.resolveReference(p));
+    const instanceMembers = mapDict(instanceType.properties!, p => t.resolveReference(p));
     expect(Object.keys(instanceMembers)).to.deep.eq(['bar', 'baz']);
     const { bar, baz } = instanceMembers;
     expect(bar!.flags).to.deep.eq(['method', 'transient']);
@@ -86,9 +84,9 @@ export class ClassFormatterAcceptanceTests {
     expect(bar!.text).to.eq('bar');
     expect(baz!.text).to.eq('baz');
     t.cleanup();
-  }
+  });
 
-  @test public async 'class with methods and properties'(): Promise<void> {
+  it('class with methods and properties', async () => {
     const code = `export class Foo {
       biz: string = '--biz--';
       bar() { return '--bar--'; }
@@ -98,10 +96,10 @@ export class ClassFormatterAcceptanceTests {
     await t.run();
     const file = t.sourceFile();
     const fileSymbol = t.resolveReference(file.symbol!);
-    const fileExports = mapDict(fileSymbol.exports!, (e) => t.resolveReference(e));
+    const fileExports = mapDict(fileSymbol.exports!, e => t.resolveReference(e));
     const classSymbol = fileExports.Foo!;
     const instanceType = t.resolveReference(classSymbol.type);
-    const instanceMembers = mapDict(instanceType.properties!, (p) => t.resolveReference(p));
+    const instanceMembers = mapDict(instanceType.properties!, p => t.resolveReference(p));
     expect(Object.keys(instanceMembers)).to.deep.eq(['biz', 'bar', 'baz']);
     const { biz, bar, baz } = instanceMembers;
     expect(bar!.flags).to.deep.eq(['method', 'transient']);
@@ -111,9 +109,9 @@ export class ClassFormatterAcceptanceTests {
     expect(baz!.text).to.eq('baz');
     expect(biz!.text).to.eq('biz');
     t.cleanup();
-  }
+  });
 
-  @test public async 'class with methods, properties and access modifiers'(): Promise<void> {
+  it('class with methods, properties and access modifiers', async () => {
     const code = `export class Foo {
       protected biz: string = '--biz--';
       public baa: string = '--baa--';
@@ -125,10 +123,10 @@ export class ClassFormatterAcceptanceTests {
     await t.run();
     const file = t.sourceFile();
     const fileSymbol = t.resolveReference(file.symbol!);
-    const fileExports = mapDict(fileSymbol.exports!, (e) => t.resolveReference(e));
+    const fileExports = mapDict(fileSymbol.exports!, e => t.resolveReference(e));
     const classSymbol = fileExports.Foo!;
     const instanceType = t.resolveReference(classSymbol.type);
-    const instanceMembers = mapDict(instanceType.properties!, (p) => t.resolveReference(p));
+    const instanceMembers = mapDict(instanceType.properties!, p => t.resolveReference(p));
     expect(Object.keys(instanceMembers)).to.deep.eq(['biz', 'baa', 'bee', 'bar', 'baz']);
     const { biz, bar, baz, bee, baa } = instanceMembers;
     expect(biz!.accessModifier).to.eq('protected');
@@ -137,9 +135,9 @@ export class ClassFormatterAcceptanceTests {
     expect(bee!.accessModifier).to.eq('private');
     expect(baa!.accessModifier).to.eq('public');
     t.cleanup();
-  }
+  });
 
-  @test public async 'class with static functions'(): Promise<void> {
+  it('class with static functions', async () => {
     const code = `export class Foo {
       public static baz(): undefined { return undefined; }
       public static biz(): unknown { return unknown; }
@@ -150,18 +148,18 @@ export class ClassFormatterAcceptanceTests {
     await t.run();
     const file = t.sourceFile();
     const fileSymbol = t.resolveReference(file.symbol!);
-    const fileExports = mapDict(fileSymbol.exports!, (e) => t.resolveReference(e));
+    const fileExports = mapDict(fileSymbol.exports!, e => t.resolveReference(e));
     const classSymbol = fileExports.Foo!;
     const classType = t.resolveReference(classSymbol.valueType);
-    const staticMembers = mapDict(classType.properties!, (p) => t.resolveReference(p));
+    const staticMembers = mapDict(classType.properties!, p => t.resolveReference(p));
     expect(Object.keys(staticMembers)).to.deep.eq(['baz', 'biz', 'bar', 'bee']);
     const instanceType = t.resolveReference(classSymbol.type);
     expect(instanceType.properties).to.eq(undefined);
 
     t.cleanup();
-  }
+  });
 
-  @test public async 'abstract class'(): Promise<void> {
+  it('abstract class', async () => {
     const code = `export abstract class Foo {
       protected abstract abstractBar(): string;
     }`;
@@ -169,22 +167,22 @@ export class ClassFormatterAcceptanceTests {
     await t.run();
     const file = t.sourceFile();
     const fileSymbol = t.resolveReference(file.symbol!);
-    const fileExports = mapDict(fileSymbol.exports!, (e) => t.resolveReference(e));
+    const fileExports = mapDict(fileSymbol.exports!, e => t.resolveReference(e));
     const classSymbol = fileExports.Foo!;
     expect(classSymbol.isAbstract).to.eq(true);
     const classType = t.resolveReference(classSymbol.valueType);
     expect(classType.properties).to.eq(undefined);
     const instanceType = t.resolveReference(classSymbol.type);
 
-    const instanceMembers = mapDict(instanceType.properties!, (p) => t.resolveReference(p));
+    const instanceMembers = mapDict(instanceType.properties!, p => t.resolveReference(p));
     expect(Object.keys(instanceMembers)).to.deep.eq(['abstractBar']);
     const { abstractBar } = instanceMembers;
     expect(abstractBar!.isAbstract).to.eq(true);
 
     t.cleanup();
-  }
+  });
 
-  @test public async 'class w/ class decorator'(): Promise<void> {
+  it('class w/ class decorator', async () => {
     const code = `
     function baz<O>(target: new () => O) {
       Object.defineProperty(target, 'bar', {
@@ -201,7 +199,7 @@ export class ClassFormatterAcceptanceTests {
     await t.run();
     const file = t.sourceFile();
     const fileSymbol = t.resolveReference(file.symbol!);
-    const fileExports = mapDict(fileSymbol.exports!, (e) => t.resolveReference(e));
+    const fileExports = mapDict(fileSymbol.exports!, e => t.resolveReference(e));
     const classSymbol = fileExports.Foo!;
     expect(!!classSymbol.isAbstract).to.eq(false);
     expect(classSymbol.decorators!.length).to.eq(1);
@@ -217,9 +215,9 @@ export class ClassFormatterAcceptanceTests {
     expect(firstDecoratorType.objectFlags).to.deep.eq(['anonymous']);
 
     t.cleanup();
-  }
+  });
 
-  @test public async 'class w/ multiple class decorators'(): Promise<void> {
+  it('class w/ multiple class decorators', async () => {
     const code = `
     function baz<O>(target: new () => O) {
       Object.defineProperty(target, 'bazzz', {
@@ -242,11 +240,11 @@ export class ClassFormatterAcceptanceTests {
     await t.run();
     const file = t.sourceFile();
     const fileSymbol = t.resolveReference(file.symbol!);
-    const fileExports = mapDict(fileSymbol.exports!, (e) => t.resolveReference(e));
+    const fileExports = mapDict(fileSymbol.exports!, e => t.resolveReference(e));
     const classSymbol = fileExports.Foo!;
     expect(!!classSymbol.isAbstract).to.eq(false);
     expect(classSymbol.decorators!.length).to.eq(2);
-    const [firstDecorator, secondDecorator] = classSymbol.decorators!.map((d) =>
+    const [firstDecorator, secondDecorator] = classSymbol.decorators!.map(d =>
       t.resolveReference(d),
     );
     expect(firstDecorator.name).to.eql('baz');
@@ -268,9 +266,9 @@ export class ClassFormatterAcceptanceTests {
     expect(secondDecoratorType.objectFlags).to.deep.eq(['anonymous']);
 
     t.cleanup();
-  }
+  });
 
-  @test public async 'class w/ non-exported base class'(): Promise<void> {
+  it('class w/ non-exported base class', async () => {
     const code = `abstract class Foo {
     protected abstract abstractBar(): string;
   }
@@ -283,7 +281,7 @@ export class ClassFormatterAcceptanceTests {
     await t.run();
     const file = t.sourceFile();
     const fileSymbol = t.resolveReference(file.symbol!);
-    const fileExports = mapDict(fileSymbol.exports!, (e) => t.resolveReference(e));
+    const fileExports = mapDict(fileSymbol.exports!, e => t.resolveReference(e));
     const classSymbol = fileExports.Baz!;
     expect(!!classSymbol.isAbstract).to.eq(false);
     const classType = t.resolveReference(classSymbol.valueType);
@@ -292,15 +290,15 @@ export class ClassFormatterAcceptanceTests {
     const instanceType = t.resolveReference(classSymbol.type);
     expect(!!instanceType.baseTypes).to.eq(true);
     expect(instanceType.baseTypes!.length).to.eq(1);
-    const [baseType] = instanceType.baseTypes!.map((bt) => t.resolveReference(bt));
+    const [baseType] = instanceType.baseTypes!.map(bt => t.resolveReference(bt));
     expect(baseType.text).to.eq('Foo');
     const baseTypeSymbol = t.resolveReference(baseType.symbol);
     expect(baseTypeSymbol.isAbstract).to.eq(true);
 
     t.cleanup();
-  }
+  });
 
-  @test.only public async 'class w/ heritage clauses'(): Promise<void> {
+  it('class w/ heritage clauses', async () => {
     const code = `class Foo {
   bar: string;
 }
@@ -319,14 +317,18 @@ export class Baz extends Foo implements HasBiz {
     await t.run();
     const file = t.sourceFile();
     const fileSymbol = t.resolveReference(file.symbol!);
-    const fileExports = mapDict(fileSymbol.exports!, (e) => t.resolveReference(e));
+    const fileExports = mapDict(fileSymbol.exports!, e => t.resolveReference(e));
     const classSymbol = fileExports.Baz!;
     expect(classSymbol.heritageClauses!.length).to.eq(2);
     expect(classSymbol.heritageClauses![0].kind).to.eq('extends');
-    expect(classSymbol.heritageClauses![0].types.map((typ) => t.resolveReference(typ).text).join(', ')).to.eq('Foo');
+    expect(
+      classSymbol.heritageClauses![0].types.map(typ => t.resolveReference(typ).text).join(', '),
+    ).to.eq('Foo');
     expect(classSymbol.heritageClauses![1].kind).to.eq('implements');
-    expect(classSymbol.heritageClauses![1].types.map((typ) => t.resolveReference(typ).text).join(', ')).to.eq('HasBiz');
+    expect(
+      classSymbol.heritageClauses![1].types.map(typ => t.resolveReference(typ).text).join(', '),
+    ).to.eq('HasBiz');
 
     t.cleanup();
-  }
-}
+  });
+});

--- a/packages/formatter/test/acceptance/enum.test.ts
+++ b/packages/formatter/test/acceptance/enum.test.ts
@@ -1,19 +1,17 @@
 import { isDefined } from '@code-to-json/utils';
 import { filterDict, mapDict } from '@code-to-json/utils-ts';
 import { expect } from 'chai';
-import { slow, suite, test } from 'mocha-typescript';
+import { describe, it } from 'mocha';
 import SingleFileAcceptanceTestCase from './helpers/test-case';
 
-@suite
-@slow(800)
-export class EnumFormatterAcceptanceTests {
-  @test public async 'regular enum'(): Promise<void> {
+describe('Enum formatter acceptance tests', () => {
+  it('regular enum', async () => {
     const code = `export enum Suit { heart, club, diamond, spade }`;
     const t = new SingleFileAcceptanceTestCase(code);
     await t.run();
     const file = t.sourceFile();
     const fileSymbol = t.resolveReference(file.symbol!);
-    const fileExports = mapDict(fileSymbol.exports!, (e) => t.resolveReference(e));
+    const fileExports = mapDict(fileSymbol.exports!, e => t.resolveReference(e));
     expect(Object.keys(fileExports)).to.deep.eq(['Suit']);
     const enumSymbol = fileExports.Suit!;
     expect(enumSymbol.name).to.eq('Suit');
@@ -21,7 +19,7 @@ export class EnumFormatterAcceptanceTests {
     expect(enumType.text).to.eq('typeof Suit');
     expect(!!enumSymbol.exports).to.eq(true, 'members exist');
     expect(Object.keys(enumSymbol.exports!)).to.deep.eq(['heart', 'club', 'diamond', 'spade']);
-    const enumMembers = mapDict(enumSymbol.exports!, (en) => t.resolveReference(en));
+    const enumMembers = mapDict(enumSymbol.exports!, en => t.resolveReference(en));
     const { heart, club, diamond, spade } = filterDict(enumMembers, isDefined);
 
     expect(heart!.flags).to.deep.eq(['enumMember']);
@@ -35,16 +33,16 @@ export class EnumFormatterAcceptanceTests {
     expect(spade!.name).to.eq('spade');
 
     t.cleanup();
-  }
+  });
 
-  @test public async 'regular enum member'(): Promise<void> {
+  it('regular enum member', async () => {
     const code = `enum Suit { heart, club, diamond, spade }
     export const x = Suit.heart;`;
     const t = new SingleFileAcceptanceTestCase(code);
     await t.run();
     const file = t.sourceFile();
     const fileSymbol = t.resolveReference(file.symbol!);
-    const fileExports = mapDict(fileSymbol.exports!, (e) => t.resolveReference(e));
+    const fileExports = mapDict(fileSymbol.exports!, e => t.resolveReference(e));
     expect(Object.keys(fileExports)).to.deep.eq(['x']);
     const enumMemberSymbol = fileExports.x!;
     expect(enumMemberSymbol.name).to.eq('x');
@@ -52,15 +50,15 @@ export class EnumFormatterAcceptanceTests {
     expect(enumType.text).to.eq('Suit.heart');
 
     t.cleanup();
-  }
+  });
 
-  @test public async 'const enum'(): Promise<void> {
+  it('const enum', async () => {
     const code = `export const enum Suit { heart, club, diamond, spade }`;
     const t = new SingleFileAcceptanceTestCase(code);
     await t.run();
     const file = t.sourceFile();
     const fileSymbol = t.resolveReference(file.symbol!);
-    const fileExports = mapDict(fileSymbol.exports!, (e) => t.resolveReference(e));
+    const fileExports = mapDict(fileSymbol.exports!, e => t.resolveReference(e));
     expect(Object.keys(fileExports)).to.deep.eq(['Suit']);
     const enumSymbol = fileExports.Suit!;
     expect(enumSymbol.name).to.eq('Suit');
@@ -69,7 +67,7 @@ export class EnumFormatterAcceptanceTests {
     expect(enumType.text).to.eq('typeof Suit');
     expect(!!enumSymbol.exports).to.eq(true, 'members exist');
     expect(Object.keys(enumSymbol.exports!)).to.deep.eq(['heart', 'club', 'diamond', 'spade']);
-    const enumMembers = mapDict(enumSymbol.exports!, (en) => t.resolveReference(en));
+    const enumMembers = mapDict(enumSymbol.exports!, en => t.resolveReference(en));
     const { heart, club, diamond, spade } = filterDict(enumMembers, isDefined);
 
     expect(heart!.flags).to.deep.eq(['enumMember']);
@@ -83,16 +81,16 @@ export class EnumFormatterAcceptanceTests {
     expect(spade!.name).to.eq('spade');
 
     t.cleanup();
-  }
+  });
 
-  @test public async 'const enum member'(): Promise<void> {
+  it('const enum member', async () => {
     const code = `const enum Suit { heart, club, diamond, spade }
     export const x = Suit.heart;`;
     const t = new SingleFileAcceptanceTestCase(code);
     await t.run();
     const file = t.sourceFile();
     const fileSymbol = t.resolveReference(file.symbol!);
-    const fileExports = mapDict(fileSymbol.exports!, (e) => t.resolveReference(e));
+    const fileExports = mapDict(fileSymbol.exports!, e => t.resolveReference(e));
     expect(Object.keys(fileExports)).to.deep.eq(['x']);
     const enumMemberSymbol = fileExports.x!;
     expect(enumMemberSymbol.name).to.eq('x');
@@ -100,5 +98,5 @@ export class EnumFormatterAcceptanceTests {
     expect(enumType.text).to.eq('Suit.heart');
 
     t.cleanup();
-  }
-}
+  });
+});

--- a/packages/formatter/test/acceptance/function.test.ts
+++ b/packages/formatter/test/acceptance/function.test.ts
@@ -1,18 +1,16 @@
 import { mapDict } from '@code-to-json/utils-ts';
 import { expect } from 'chai';
-import { slow, suite, test } from 'mocha-typescript';
+import { describe, it } from 'mocha';
 import SingleFileAcceptanceTestCase from './helpers/test-case';
 
-@suite
-@slow(800)
-export class FunctionAcceptanceTests {
-  @test public async 'simple function declaration'(): Promise<void> {
+describe('Function acceptance tests', () => {
+  it('simple function declaration', async () => {
     const code = `export function add(a: number, b: number) { return a + b; }`;
     const t = new SingleFileAcceptanceTestCase(code);
     await t.run();
     const file = t.sourceFile();
     const fileSymbol = t.resolveReference(file.symbol!);
-    const fileExports = mapDict(fileSymbol.exports!, (e) => t.resolveReference(e));
+    const fileExports = mapDict(fileSymbol.exports!, e => t.resolveReference(e));
     const fnSymbol = fileExports.add!;
     expect(fnSymbol.text).to.eq('add');
     expect(!!fnSymbol.isAsync).to.eq(false);
@@ -22,18 +20,18 @@ export class FunctionAcceptanceTests {
     expect(fnType.callSignatures!.length).to.eq(1);
     expect(fnType.callSignatures![0].parameters!.length).to.eq(2);
     const [a, b] = fnType.callSignatures![0].parameters!;
-    const [atype, btype] = [a, b].map((x) => t.resolveReference(x.type));
+    const [atype, btype] = [a, b].map(x => t.resolveReference(x.type));
     expect(atype.text).to.eq('number');
     expect(btype.text).to.eq('number');
-  }
+  });
 
-  @test public async 'simple async function declaration'(): Promise<void> {
+  it('simple async function declaration', async () => {
     const code = `export async function add(a: number, b: number) { return a + b; }`;
     const t = new SingleFileAcceptanceTestCase(code);
     await t.run();
     const file = t.sourceFile();
     const fileSymbol = t.resolveReference(file.symbol!);
-    const fileExports = mapDict(fileSymbol.exports!, (e) => t.resolveReference(e));
+    const fileExports = mapDict(fileSymbol.exports!, e => t.resolveReference(e));
     const fnSymbol = fileExports.add!;
     expect(fnSymbol.text).to.eq('add');
     expect(fnSymbol.isAsync).to.eq(true);
@@ -43,12 +41,12 @@ export class FunctionAcceptanceTests {
     expect(fnType.callSignatures!.length).to.eq(1);
     expect(fnType.callSignatures![0].parameters!.length).to.eq(2);
     const [a, b] = fnType.callSignatures![0].parameters!;
-    const [atype, btype] = [a, b].map((x) => t.resolveReference(x.type));
+    const [atype, btype] = [a, b].map(x => t.resolveReference(x.type));
     expect(atype.text).to.eq('number');
     expect(btype.text).to.eq('number');
-  }
+  });
 
-  @test public async 'overloaded function declaration'(): Promise<void> {
+  it('overloaded function declaration', async () => {
     const code = `
     export function add(a: number, b: number): number;
     export function add(a: string, b: string): string;
@@ -58,7 +56,7 @@ export class FunctionAcceptanceTests {
     await t.run();
     const file = t.sourceFile();
     const fileSymbol = t.resolveReference(file.symbol!);
-    const fileExports = mapDict(fileSymbol.exports!, (e) => t.resolveReference(e));
+    const fileExports = mapDict(fileSymbol.exports!, e => t.resolveReference(e));
     const fnSymbol = fileExports.add!;
     expect(fnSymbol.text).to.eq('add');
     expect(!!fnSymbol.isAsync).to.eq(false);
@@ -75,23 +73,23 @@ export class FunctionAcceptanceTests {
     expect(fnType.callSignatures![1].text).to.eq('(a: string, b: string): string');
 
     const [a, b] = fnType.callSignatures![0].parameters!;
-    const [atype, btype] = [a, b].map((x) => t.resolveReference(x.type));
+    const [atype, btype] = [a, b].map(x => t.resolveReference(x.type));
     expect(atype.text).to.eq('number');
     expect(btype.text).to.eq('number');
 
     const [c, d] = fnType.callSignatures![1].parameters!;
-    const [ctype, dtype] = [c, d].map((x) => t.resolveReference(x.type));
+    const [ctype, dtype] = [c, d].map(x => t.resolveReference(x.type));
     expect(ctype.text).to.eq('string');
     expect(dtype.text).to.eq('string');
-  }
+  });
 
-  @test public async 'function w/ rest param'(): Promise<void> {
+  it('function w/ rest param', async () => {
     const code = `export function x(...args: string[]) { return args.join(', '); }`;
     const t = new SingleFileAcceptanceTestCase(code);
     await t.run();
     const file = t.sourceFile();
     const fileSymbol = t.resolveReference(file.symbol!);
-    const fileExports = mapDict(fileSymbol.exports!, (e) => t.resolveReference(e));
+    const fileExports = mapDict(fileSymbol.exports!, e => t.resolveReference(e));
     const fnSymbol = fileExports.x!;
     expect(fnSymbol.text).to.eq('x');
     expect(!!fnSymbol.isAsync).to.eq(false);
@@ -102,7 +100,7 @@ export class FunctionAcceptanceTests {
     expect(fnType.callSignatures![0].parameters!.length).to.eq(1);
     expect(fnType.callSignatures![0].hasRestParameter).to.eq(true);
     const [a] = fnType.callSignatures![0].parameters!;
-    const [atype] = [a].map((x) => t.resolveReference(x.type));
+    const [atype] = [a].map(x => t.resolveReference(x.type));
     expect(atype.text).to.eq('string[]');
-  }
-}
+  });
+});

--- a/packages/formatter/test/acceptance/interfaces.test.ts
+++ b/packages/formatter/test/acceptance/interfaces.test.ts
@@ -1,12 +1,10 @@
 import { mapDict } from '@code-to-json/utils-ts';
 import { expect } from 'chai';
-import { slow, suite, test } from 'mocha-typescript';
+import { describe, it } from 'mocha';
 import SingleFileAcceptanceTestCase from './helpers/test-case';
 
-@suite
-@slow(800)
-export class InterfaceAcceptanceTests {
-  @test public async 'simple interface'(): Promise<void> {
+describe('Interface formatting acceptance tests', () => {
+  it('simple interface', async () => {
     const code = `export interface Foo { bar: string; }`;
     const t = new SingleFileAcceptanceTestCase(code);
     await t.run();
@@ -37,9 +35,9 @@ export class InterfaceAcceptanceTests {
     });
 
     t.cleanup();
-  }
+  });
 
-  @test public async 'interface w/ type param'(): Promise<void> {
+  it('interface w/ type param', async () => {
     const code = `export interface Foo<T> { bar: T; }`;
     const t = new SingleFileAcceptanceTestCase(code);
     await t.run();
@@ -73,9 +71,9 @@ export class InterfaceAcceptanceTests {
     });
 
     t.cleanup();
-  }
+  });
 
-  @test public async 'interface w/ constrained type param'(): Promise<void> {
+  it('interface w/ constrained type param', async () => {
     const code = `export interface Foo<T extends number> { bar: T; }`;
     const t = new SingleFileAcceptanceTestCase(code);
     await t.run();
@@ -109,9 +107,9 @@ export class InterfaceAcceptanceTests {
     });
 
     t.cleanup();
-  }
+  });
 
-  @test public async 'interface w/ string index signature'(): Promise<void> {
+  it('interface w/ string index signature', async () => {
     const code = `export interface Foo<T> { [k: string]: T }`;
     const t = new SingleFileAcceptanceTestCase(code);
     await t.run();
@@ -132,9 +130,9 @@ export class InterfaceAcceptanceTests {
     expect(interfaceType.properties).to.eq(undefined);
 
     t.cleanup();
-  }
+  });
 
-  @test public async 'interface w/ string and number index signatures'(): Promise<void> {
+  it('interface w/ string and number index signatures', async () => {
     const code = `export interface Foo<T> { [k: string]: T; [k: number]: T[]; }`;
     const t = new SingleFileAcceptanceTestCase(code);
     await t.run();
@@ -156,9 +154,9 @@ export class InterfaceAcceptanceTests {
     expect(interfaceType.properties).to.eq(undefined);
 
     t.cleanup();
-  }
+  });
 
-  @test public async 'interface w/ index signature involving union type'(): Promise<void> {
+  it('interface w/ index signature involving union type', async () => {
     const code = `export interface Foo<T> { [k: string]: T | T[] }`;
     const t = new SingleFileAcceptanceTestCase(code);
     await t.run();
@@ -186,12 +184,9 @@ export class InterfaceAcceptanceTests {
     expect(interfaceType.properties).to.eq(undefined);
 
     t.cleanup();
-  }
+  });
 
-  @test
-  public async 'interface w/ index signature involving union and intersection types'(): Promise<
-    void
-  > {
+  it('interface w/ index signature involving union and intersection types', async () => {
     const code = `export interface Foo<T> { [k: string]: (T | T[]) & { foo: string } }`;
     const t = new SingleFileAcceptanceTestCase(code);
     await t.run();
@@ -237,5 +232,5 @@ export class InterfaceAcceptanceTests {
     expect(interfaceType.properties).to.eq(undefined);
 
     t.cleanup();
-  }
-}
+  });
+});

--- a/packages/formatter/test/acceptance/typealias.test.ts
+++ b/packages/formatter/test/acceptance/typealias.test.ts
@@ -1,12 +1,10 @@
 import { mapDict } from '@code-to-json/utils-ts';
 import { expect } from 'chai';
-import { slow, suite, test } from 'mocha-typescript';
+import { describe, it } from 'mocha';
 import SingleFileAcceptanceTestCase from './helpers/test-case';
 
-@suite
-@slow(800)
-export class TypeAliasAcceptanceTests {
-  @test public async 'simple type alias'(): Promise<void> {
+describe('TypeAlias formatting acceptance tests', () => {
+  it('simple type alias', async () => {
     const code = 'export type Foo = { bar: string }';
     const t = new SingleFileAcceptanceTestCase(code);
     await t.run();
@@ -21,9 +19,9 @@ export class TypeAliasAcceptanceTests {
     ).to.deep.eq({
       bar: 'string',
     });
-  }
+  });
 
-  @test public async 'conditional type'(): Promise<void> {
+  it('conditional type', async () => {
     const code = `export type Bar<T> = T extends string ? T : number[];
     export const x: Bar<'foo'> = 'foo';
     export const y: Bar<Promise<string>> = [1, 2, 3];`;
@@ -57,5 +55,5 @@ export class TypeAliasAcceptanceTests {
     expect(falseType.text).to.eq('number[]');
     expect(trueType.flags).to.deep.eq(['substitution']);
     expect(falseType.flags).to.deep.eq(['object']);
-  }
-}
+  });
+});

--- a/packages/formatter/test/acceptance/variable.test.ts
+++ b/packages/formatter/test/acceptance/variable.test.ts
@@ -1,18 +1,16 @@
 import { mapDict } from '@code-to-json/utils-ts';
 import { expect } from 'chai';
-import { slow, suite, test } from 'mocha-typescript';
+import { describe, it } from 'mocha';
 import SingleFileAcceptanceTestCase from './helpers/test-case';
 
-@suite
-@slow(800)
-export class VariableAcceptanceTests {
-  @test public async 'let x = "foo";'(): Promise<void> {
+describe('Variable formatting acceptance tests', () => {
+  it('let x = "foo";', async () => {
     const code = `export let x = "foo";`;
     const t = new SingleFileAcceptanceTestCase(code);
     await t.run();
     const file = t.sourceFile();
     const fileSymbol = t.resolveReference(file.symbol!);
-    const fileExports = mapDict(fileSymbol.exports!, (e) => t.resolveReference(e));
+    const fileExports = mapDict(fileSymbol.exports!, e => t.resolveReference(e));
     const varSymbol = fileExports.x!;
     expect(varSymbol.text).to.eq('x');
     expect(varSymbol.flags).to.deep.eq(['variable']);
@@ -20,15 +18,15 @@ export class VariableAcceptanceTests {
     expect(varType.text).to.eq('string');
     expect(varType.flags).to.deep.eq(['string']);
     t.cleanup();
-  }
+  });
 
-  @test public async 'const x = "foo";'(): Promise<void> {
+  it('const x = "foo";', async () => {
     const code = `export const x = "foo";`;
     const t = new SingleFileAcceptanceTestCase(code);
     await t.run();
     const file = t.sourceFile();
     const fileSymbol = t.resolveReference(file.symbol!);
-    const fileExports = mapDict(fileSymbol.exports!, (e) => t.resolveReference(e));
+    const fileExports = mapDict(fileSymbol.exports!, e => t.resolveReference(e));
     const varSymbol = fileExports.x!;
     expect(varSymbol.text).to.eq('x');
     expect(varSymbol.flags).to.deep.eq(['variable']);
@@ -36,15 +34,15 @@ export class VariableAcceptanceTests {
     expect(varType.text).to.eq('"foo"');
     expect(varType.flags).to.deep.eq(['stringLiteral']);
     t.cleanup();
-  }
+  });
 
-  @test public async 'const x: string = "foo";'(): Promise<void> {
+  it('const x: string = "foo";', async () => {
     const code = `export const x: string = "foo";`;
     const t = new SingleFileAcceptanceTestCase(code);
     await t.run();
     const file = t.sourceFile();
     const fileSymbol = t.resolveReference(file.symbol!);
-    const fileExports = mapDict(fileSymbol.exports!, (e) => t.resolveReference(e));
+    const fileExports = mapDict(fileSymbol.exports!, e => t.resolveReference(e));
     const varSymbol = fileExports.x!;
     expect(varSymbol.text).to.eq('x');
     expect(varSymbol.flags).to.deep.eq(['variable']);
@@ -52,15 +50,15 @@ export class VariableAcceptanceTests {
     expect(varType.text).to.eq('string');
     expect(varType.flags).to.deep.eq(['string']);
     t.cleanup();
-  }
+  });
 
-  @test public async 'const x: number = 42;'(): Promise<void> {
+  it('const x: number = 42;', async () => {
     const code = `export const x: number = 42;`;
     const t = new SingleFileAcceptanceTestCase(code);
     await t.run();
     const file = t.sourceFile();
     const fileSymbol = t.resolveReference(file.symbol!);
-    const fileExports = mapDict(fileSymbol.exports!, (e) => t.resolveReference(e));
+    const fileExports = mapDict(fileSymbol.exports!, e => t.resolveReference(e));
     const varSymbol = fileExports.x!;
     expect(varSymbol.text).to.eq('x');
     expect(varSymbol.flags).to.deep.eq(['variable']);
@@ -68,15 +66,15 @@ export class VariableAcceptanceTests {
     expect(varType.text).to.eq('number');
     expect(varType.flags).to.deep.eq(['number']);
     t.cleanup();
-  }
+  });
 
-  @test public async 'let x: never;'(): Promise<void> {
+  it('let x: never;', async () => {
     const code = `export let x: never;`;
     const t = new SingleFileAcceptanceTestCase(code);
     await t.run();
     const file = t.sourceFile();
     const fileSymbol = t.resolveReference(file.symbol!);
-    const fileExports = mapDict(fileSymbol.exports!, (e) => t.resolveReference(e));
+    const fileExports = mapDict(fileSymbol.exports!, e => t.resolveReference(e));
     const varSymbol = fileExports.x!;
     expect(varSymbol.text).to.eq('x');
     expect(varSymbol.flags).to.deep.eq(['variable']);
@@ -84,15 +82,15 @@ export class VariableAcceptanceTests {
     expect(varType.text).to.eq('never');
     expect(varType.flags).to.deep.eq(['never']);
     t.cleanup();
-  }
+  });
 
-  @test public async 'const x = 42;'(): Promise<void> {
+  it('const x = 42;', async () => {
     const code = `export const x = 42;`;
     const t = new SingleFileAcceptanceTestCase(code);
     await t.run();
     const file = t.sourceFile();
     const fileSymbol = t.resolveReference(file.symbol!);
-    const fileExports = mapDict(fileSymbol.exports!, (e) => t.resolveReference(e));
+    const fileExports = mapDict(fileSymbol.exports!, e => t.resolveReference(e));
     const varSymbol = fileExports.x!;
     expect(varSymbol.text).to.eq('x');
     expect(varSymbol.flags).to.deep.eq(['variable']);
@@ -100,15 +98,15 @@ export class VariableAcceptanceTests {
     expect(varType.text).to.eq('42');
     expect(varType.flags).to.deep.eq(['numberLiteral']);
     t.cleanup();
-  }
+  });
 
-  @test public async 'const x = () => "foo";'(): Promise<void> {
+  it('const x = () => "foo";', async () => {
     const code = `export const x = () => "foo";`;
     const t = new SingleFileAcceptanceTestCase(code);
     await t.run();
     const file = t.sourceFile();
     const fileSymbol = t.resolveReference(file.symbol!);
-    const fileExports = mapDict(fileSymbol.exports!, (e) => t.resolveReference(e));
+    const fileExports = mapDict(fileSymbol.exports!, e => t.resolveReference(e));
     const varSymbol = fileExports.x!;
     expect(varSymbol.text).to.eq('x');
     expect(varSymbol.flags).to.deep.eq(['variable']);
@@ -117,15 +115,15 @@ export class VariableAcceptanceTests {
     expect(varType.flags).to.deep.eq(['object']);
     expect(varType.objectFlags).to.deep.eq(['anonymous']);
     t.cleanup();
-  }
+  });
 
-  @test public async 'const x: null = null;'(): Promise<void> {
+  it('const x: null = null;', async () => {
     const code = `export const x: null = null;`;
     const t = new SingleFileAcceptanceTestCase(code);
     await t.run();
     const file = t.sourceFile();
     const fileSymbol = t.resolveReference(file.symbol!);
-    const fileExports = mapDict(fileSymbol.exports!, (e) => t.resolveReference(e));
+    const fileExports = mapDict(fileSymbol.exports!, e => t.resolveReference(e));
     const varSymbol = fileExports.x!;
     expect(varSymbol.text).to.eq('x');
     expect(varSymbol.flags).to.deep.eq(['variable']);
@@ -133,15 +131,15 @@ export class VariableAcceptanceTests {
     expect(varType.text).to.eq('null');
     expect(varType.flags).to.deep.eq(['null']);
     t.cleanup();
-  }
+  });
 
-  @test public async 'const x = null;'(): Promise<void> {
+  it('const x = null;', async () => {
     const code = `export const x = null;`;
     const t = new SingleFileAcceptanceTestCase(code);
     await t.run();
     const file = t.sourceFile();
     const fileSymbol = t.resolveReference(file.symbol!);
-    const fileExports = mapDict(fileSymbol.exports!, (e) => t.resolveReference(e));
+    const fileExports = mapDict(fileSymbol.exports!, e => t.resolveReference(e));
     const varSymbol = fileExports.x!;
     expect(varSymbol.text).to.eq('x');
     expect(varSymbol.flags).to.deep.eq(['variable']);
@@ -149,15 +147,15 @@ export class VariableAcceptanceTests {
     expect(varType.text).to.eq('any');
     expect(varType.flags).to.deep.eq(['any']);
     t.cleanup();
-  }
+  });
 
-  @test public async 'const x = true;'(): Promise<void> {
+  it('const x = true;', async () => {
     const code = `export const x = true;`;
     const t = new SingleFileAcceptanceTestCase(code);
     await t.run();
     const file = t.sourceFile();
     const fileSymbol = t.resolveReference(file.symbol!);
-    const fileExports = mapDict(fileSymbol.exports!, (e) => t.resolveReference(e));
+    const fileExports = mapDict(fileSymbol.exports!, e => t.resolveReference(e));
     const varSymbol = fileExports.x!;
     expect(varSymbol.text).to.eq('x');
     expect(varSymbol.flags).to.deep.eq(['variable']);
@@ -165,15 +163,15 @@ export class VariableAcceptanceTests {
     expect(varType.text).to.eq('true');
     expect(varType.flags).to.deep.eq(['booleanLiteral']);
     t.cleanup();
-  }
+  });
 
-  @test public async 'const x = Symbol("abc");'(): Promise<void> {
+  it('const x = Symbol("abc");', async () => {
     const code = `export const x = Symbol("abc");`;
     const t = new SingleFileAcceptanceTestCase(code);
     await t.run();
     const file = t.sourceFile();
     const fileSymbol = t.resolveReference(file.symbol!);
-    const fileExports = mapDict(fileSymbol.exports!, (e) => t.resolveReference(e));
+    const fileExports = mapDict(fileSymbol.exports!, e => t.resolveReference(e));
     const varSymbol = fileExports.x!;
     expect(varSymbol.text).to.eq('x');
     expect(varSymbol.flags).to.deep.eq(['variable']);
@@ -181,15 +179,15 @@ export class VariableAcceptanceTests {
     expect(varType.text).to.eq('unique symbol');
     expect(varType.flags).to.deep.eq(['uniqueESSymbol']);
     t.cleanup();
-  }
+  });
 
-  @test public async 'let x = Symbol("abc");'(): Promise<void> {
+  it('let x = Symbol("abc");', async () => {
     const code = `export let x = Symbol("abc");`;
     const t = new SingleFileAcceptanceTestCase(code);
     await t.run();
     const file = t.sourceFile();
     const fileSymbol = t.resolveReference(file.symbol!);
-    const fileExports = mapDict(fileSymbol.exports!, (e) => t.resolveReference(e));
+    const fileExports = mapDict(fileSymbol.exports!, e => t.resolveReference(e));
     const varSymbol = fileExports.x!;
     expect(varSymbol.text).to.eq('x');
     expect(varSymbol.flags).to.deep.eq(['variable']);
@@ -197,15 +195,15 @@ export class VariableAcceptanceTests {
     expect(varType.text).to.eq('symbol');
     expect(varType.flags).to.deep.eq(['eSSymbol']);
     t.cleanup();
-  }
+  });
 
-  @test public async 'const x: any = 41;'(): Promise<void> {
+  it('const x: any = 41;', async () => {
     const code = `export const x: any = 41;`;
     const t = new SingleFileAcceptanceTestCase(code);
     await t.run();
     const file = t.sourceFile();
     const fileSymbol = t.resolveReference(file.symbol!);
-    const fileExports = mapDict(fileSymbol.exports!, (e) => t.resolveReference(e));
+    const fileExports = mapDict(fileSymbol.exports!, e => t.resolveReference(e));
     const varSymbol = fileExports.x!;
     expect(varSymbol.text).to.eq('x');
     expect(varSymbol.flags).to.deep.eq(['variable']);
@@ -213,9 +211,9 @@ export class VariableAcceptanceTests {
     expect(varType.text).to.eq('any');
     expect(varType.flags).to.deep.eq(['any']);
     t.cleanup();
-  }
+  });
 
-  @test public async 'const x: {foo: "bar"} = {foo: "bar" }'(): Promise<void> {
+  it('const x: {foo: "bar"} = {foo: "bar" }', async () => {
     const code = `
   interface Foo {foo: "bar"};
   export const x: Foo = {foo: "bar" }`;
@@ -223,7 +221,7 @@ export class VariableAcceptanceTests {
     await t.run();
     const file = t.sourceFile();
     const fileSymbol = t.resolveReference(file.symbol!);
-    const fileExports = mapDict(fileSymbol.exports!, (e) => t.resolveReference(e));
+    const fileExports = mapDict(fileSymbol.exports!, e => t.resolveReference(e));
     const varSymbol = fileExports.x!;
     expect(varSymbol.text).to.eq('x');
     expect(varSymbol.flags).to.deep.eq(['variable']);
@@ -232,5 +230,5 @@ export class VariableAcceptanceTests {
     expect(varType.flags).to.deep.eq(['object']);
     expect(varType.objectFlags).to.deep.eq(['interface']);
     t.cleanup();
-  }
-}
+  });
+});

--- a/packages/formatter/test/formatters/flags.test.ts
+++ b/packages/formatter/test/formatters/flags.test.ts
@@ -1,11 +1,9 @@
 import { expect } from 'chai';
-import { suite, test } from 'mocha-typescript';
+import { describe, it } from 'mocha';
 import formatFlags from '../../src/flags';
 
-@suite
-export class FlagFormatterTests {
-  @test
-  public async 'pass-through (capitalization only) flags'(): Promise<void> {
+describe('Flag formatting tests', () => {
+  it('pass-through (capitalization only) flags', async () => {
     [
       'Class',
       'Function',
@@ -23,28 +21,24 @@ export class FlagFormatterTests {
       'Prototype',
       'Constructor',
       'TypeParameter',
-    ].forEach((flag) => {
+    ].forEach(flag => {
       expect(formatFlags([flag])).to.eql([flag[0].toLowerCase() + flag.substr(1)]);
     });
-  }
+  });
 
-  @test
-  public async 'undefined flag'(): Promise<void> {
+  it('undefined flag', async () => {
     expect(formatFlags()).to.eql([]);
-  }
+  });
 
-  @test
-  public async blockScopedVariable(): Promise<void> {
+  it('blockScopedVariable', async () => {
     expect(formatFlags(['BlockScopedVariable'])).to.eql(['variable']);
-  }
+  });
 
-  @test
-  public async valueModule(): Promise<void> {
+  it('valueModule', async () => {
     expect(formatFlags(['ValueModule'])).to.eql(['module']);
-  }
+  });
 
-  @test
-  public async 'null flag'(): Promise<void> {
+  it('null flag', async () => {
     expect(() => formatFlags(null as any)).to.throw('Reached code that should be unreachable');
-  }
-}
+  });
+});

--- a/packages/formatter/test/formatters/source-file.test.ts
+++ b/packages/formatter/test/formatters/source-file.test.ts
@@ -1,15 +1,13 @@
 import { WalkerOutputData } from '@code-to-json/core';
 import { createRef } from '@code-to-json/utils';
 import { expect } from 'chai';
-import { suite, test } from 'mocha-typescript';
+import { describe, it } from 'mocha';
 import { FormatterRefRegistry } from '../../src';
 import { create } from '../../src/data-collector';
 import formatSourceFile from '../../src/source-file';
 
-@suite
-export class SourceFileFormatterTests {
-  @test
-  public async 'file without exports'(): Promise<void> {
+describe('SourceFile formatting tests', () => {
+  it('file without exports', async () => {
     const wo: WalkerOutputData = {
       symbols: {},
       types: {},
@@ -47,10 +45,9 @@ export class SourceFileFormatterTests {
       kind: 'sourceFile',
       isDeclarationFile: false,
     });
-  }
+  });
 
-  @test
-  public async 'file with exports'(): Promise<void> {
+  it('file with exports', async () => {
     const wo: WalkerOutputData = {
       symbols: {
         12345: {
@@ -99,5 +96,5 @@ export class SourceFileFormatterTests {
       isDeclarationFile: false,
       kind: 'sourceFile',
     });
-  }
-}
+  });
+});

--- a/packages/formatter/test/mocha.opts
+++ b/packages/formatter/test/mocha.opts
@@ -1,4 +1,3 @@
---ui mocha-typescript
 --require ts-node/register
 --require source-map-support/register
 --timeout 60000

--- a/packages/formatter/test/public-api-surface.test.ts
+++ b/packages/formatter/test/public-api-surface.test.ts
@@ -1,18 +1,15 @@
 import { expect } from 'chai';
-import { suite, test } from 'mocha-typescript';
+import { describe, it } from 'mocha';
 import * as Exports from '../src/index';
 
 const { formatWalkerOutput } = Exports;
 
-@suite
-export class PublicApiSurface {
-  @test
-  public 'formatWalkerOutput exists'(): void {
+describe('Public API surface tests', () => {
+  it('formatWalkerOutput exists', () => {
     expect(formatWalkerOutput).to.be.a('function');
-  }
+  });
 
-  @test
-  public 'only intended exports'(): void {
+  it('only intended exports', () => {
     expect(Object.keys(Exports).sort()).to.deep.eq(['formatWalkerOutput']);
-  }
-}
+  });
+});

--- a/packages/formatter/test/resolve-reference.test.ts
+++ b/packages/formatter/test/resolve-reference.test.ts
@@ -1,12 +1,10 @@
 import { createRef, Ref } from '@code-to-json/utils';
 import { expect } from 'chai';
-import { suite, test } from 'mocha-typescript';
+import { describe, it } from 'mocha';
 import resolveReference from '../src/resolve-reference';
 
-@suite
-export class ResolveReferenceTests {
-  @test
-  public type(): void {
+describe('Resolve reference tests', () => {
+  it('type', () => {
     const typeRef: Ref<'type'> = (createRef as any)('type', '12345');
     const resolved = resolveReference(
       {
@@ -19,10 +17,9 @@ export class ResolveReferenceTests {
       typeRef,
     );
     expect(resolved).to.deep.eq({ id: '12345' });
-  }
+  });
 
-  @test
-  public symbol(): void {
+  it('symbol', () => {
     const symbolRef: Ref<'symbol'> = (createRef as any)('symbol', '12345');
     const resolved = resolveReference(
       {
@@ -35,10 +32,9 @@ export class ResolveReferenceTests {
       symbolRef,
     );
     expect(resolved).to.deep.eq({ id: '12345' });
-  }
+  });
 
-  @test
-  public node(): void {
+  it('node', () => {
     const nodeRef: Ref<'node'> = (createRef as any)('node', '12345');
     const resolved = resolveReference(
       {
@@ -51,10 +47,9 @@ export class ResolveReferenceTests {
       nodeRef,
     );
     expect(resolved).to.deep.eq({ id: '12345' });
-  }
+  });
 
-  @test
-  public declaration(): void {
+  it('declaration', () => {
     const declarationRef: Ref<'declaration'> = (createRef as any)('declaration', '12345');
     const resolved = resolveReference(
       {
@@ -67,10 +62,9 @@ export class ResolveReferenceTests {
       declarationRef,
     );
     expect(resolved).to.deep.eq({ id: '12345' });
-  }
+  });
 
-  @test
-  public sourceFile(): void {
+  it('sourceFile', () => {
     const sourceFileRef: Ref<'sourceFile'> = (createRef as any)('sourceFile', '12345');
     const resolved = resolveReference(
       {
@@ -83,5 +77,5 @@ export class ResolveReferenceTests {
       sourceFileRef,
     );
     expect(resolved).to.deep.eq({ id: '12345' });
-  }
-}
+  });
+});

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -36,7 +36,6 @@
     "eslint-plugin-node": "8.0.1",
     "eslint-plugin-prettier": "3.0.1",
     "mocha": "5.2.0",
-    "mocha-typescript": "1.1.17",
     "nyc": "13.3.0",
     "remark-cli": "6.0.1",
     "remark-lint": "6.0.4",

--- a/packages/schema/test/first.test.ts
+++ b/packages/schema/test/first.test.ts
@@ -1,11 +1,9 @@
 import { expect } from 'chai';
-import { suite, test } from 'mocha-typescript';
+import { describe, it } from 'mocha';
 import { formattedSchema } from '../src/index';
 
-@suite
-export class PublicApiSurface {
-  @test
-  public 'schema exists'(): void {
+describe('Public API surface tests', () => {
+  it('schema exists', () => {
     expect(formattedSchema).to.be.a('object');
-  }
-}
+  });
+});

--- a/packages/schema/test/mocha.opts
+++ b/packages/schema/test/mocha.opts
@@ -1,4 +1,3 @@
---ui mocha-typescript
 --require ts-node/register
 --require source-map-support/register
 --timeout 60000

--- a/packages/test-helpers/package.json
+++ b/packages/test-helpers/package.json
@@ -48,7 +48,6 @@
     "eslint-plugin-node": "8.0.1",
     "eslint-plugin-prettier": "3.0.1",
     "mocha": "5.2.0",
-    "mocha-typescript": "1.1.17",
     "nyc": "13.3.0",
     "remark-cli": "6.0.1",
     "remark-lint": "6.0.4",

--- a/packages/test-helpers/test/dir-tree.test.ts
+++ b/packages/test-helpers/test/dir-tree.test.ts
@@ -1,24 +1,21 @@
 import { expect } from 'chai';
 import * as fs from 'fs';
-import { suite, test } from 'mocha-typescript';
+import { describe, it } from 'mocha';
 import * as path from 'path';
 import * as tmp from 'tmp';
 import { asString } from '../src/dir-tree';
 
-@suite
-export class DirTreeTests {
-  @test
-  public async 'empty folder'(): Promise<void> {
+describe('DirTree tests', () => {
+  it('empty folder', async () => {
     const workspace = tmp.dirSync({ unsafeCleanup: true });
     expect(workspace.name.length).to.be.greaterThan(0, 'Temp folder path is a non-empty string');
     const newFolder = path.join(workspace.name, 'new-folder');
     fs.mkdirSync(newFolder);
     expect(asString(newFolder)).to.eq('(empty)');
     workspace.removeCallback();
-  }
+  });
 
-  @test
-  public async 'folder with a file'(): Promise<void> {
+  it('folder with a file', async () => {
     const workspace = tmp.dirSync({ unsafeCleanup: true });
     expect(workspace.name.length).to.be.greaterThan(0, 'Temp folder path is a non-empty string');
     const newFolder = path.join(workspace.name, 'new-folder');
@@ -26,5 +23,5 @@ export class DirTreeTests {
     fs.writeFileSync(path.join(newFolder, 'file.txt'), 'Hello, world!');
     expect(asString(newFolder).trim()).to.eq('└─ file.txt');
     workspace.removeCallback();
-  }
-}
+  });
+});

--- a/packages/test-helpers/test/mocha.opts
+++ b/packages/test-helpers/test/mocha.opts
@@ -1,4 +1,3 @@
---ui mocha-typescript
 --require ts-node/register
 --require source-map-support/register
 --timeout 60000

--- a/packages/test-helpers/test/test-case-integrity.test.ts
+++ b/packages/test-helpers/test/test-case-integrity.test.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import * as fs from 'fs-extra';
-import { suite, test } from 'mocha-typescript';
 import * as path from 'path';
+import { describe, it } from 'mocha';
 
 const TEST_CASES_FOLDER_PATH = path.join(__dirname, '..', 'test-cases');
 
@@ -13,10 +13,8 @@ const TEST_CASE_FOLDERS = fs
   // and transformed into absolute paths
   .map(f => path.join(TEST_CASES_FOLDER_PATH, f));
 
-@suite
-export class TestCaseIntegrity {
-  @test
-  public async 'every test case has a tsconfig.json file'(): Promise<void> {
+describe('Test case integrity', () => {
+  it('every test case has a tsconfig.json file', async () => {
     // each test case
     const offenders = TEST_CASE_FOLDERS.filter(projectRoot => {
       // this should be the path of tsconfig.json
@@ -28,10 +26,9 @@ export class TestCaseIntegrity {
       return true;
     });
     expect(offenders.join(',')).to.eq('');
-  }
+  });
 
-  @test
-  public async 'every test case has a src folder'(): Promise<void> {
+  it('every test case has a src folder', async () => {
     // each test case
     const offenders = TEST_CASE_FOLDERS.filter(projectRoot => {
       // should be the path of the src folder
@@ -43,10 +40,9 @@ export class TestCaseIntegrity {
       return true;
     });
     expect(offenders.join(',')).to.eq('');
-  }
+  });
 
-  @test
-  public async 'every test case has a src/index.ts or src/index.js file'(): Promise<void> {
+  it('every test case has a src/index.ts or src/index.js file', async () => {
     // each test case
     const offenders = TEST_CASE_FOLDERS.filter(projectRoot => {
       // this should be the index.ts file
@@ -58,5 +54,5 @@ export class TestCaseIntegrity {
       return true;
     });
     expect(offenders.join(',')).to.eq('');
-  }
-}
+  });
+});

--- a/packages/test-helpers/test/test-case.test.ts
+++ b/packages/test-helpers/test/test-case.test.ts
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 import * as fs from 'fs';
-import { suite, test } from 'mocha-typescript';
+import { describe, it } from 'mocha';
 import * as path from 'path';
 import * as tmp from 'tmp';
 import { createTempFixtureFolder } from '../src/file-fixtures';
@@ -9,10 +9,8 @@ import { setupTestCase } from '../src/index';
 export const TEST_CASES_FOLDER_PATH = path.join(__dirname, '..', 'test-cases');
 const SIMPLE_VARIABLES_TEST_CASE_NAME = 'simple-variables';
 
-@suite
-export class TestCaseCreation {
-  @test
-  public async 'Create a new test case folder from a template'(): Promise<void> {
+describe('Test case creation', () => {
+  it('Create a new test case folder from a template', async () => {
     const { rootPath, cleanup } = await createTempFixtureFolder(
       path.join(TEST_CASES_FOLDER_PATH, SIMPLE_VARIABLES_TEST_CASE_NAME),
     );
@@ -21,20 +19,18 @@ export class TestCaseCreation {
     expect(rootPath).length.to.be.greaterThan(0);
     expect(cleanup).to.be.an.instanceOf(Function);
     cleanup();
-  }
+  });
 
-  @test
-  public async 'Attempting to create a test case from a non-existent folder'(): Promise<void> {
+  it('Attempting to create a test case from a non-existent folder', async () => {
     const errors: Error[] = [];
     await createTempFixtureFolder(path.join(TEST_CASES_FOLDER_PATH, 'foo-bar-baz')).catch(err => {
       errors.push(err);
     });
     expect(errors.length).to.eq(1);
     expect(errors[0].message).to.contain('does not exist');
-  }
+  });
 
-  @test
-  public async 'Attempting to create a test case from a non-folder (file)'(): Promise<void> {
+  it('Attempting to create a test case from a non-folder (file)', async () => {
     const workspace = tmp.dirSync({ unsafeCleanup: true });
     const filePath = path.join(workspace.name, 'file.txt');
     fs.writeFileSync(filePath, 'hello world');
@@ -44,10 +40,9 @@ export class TestCaseCreation {
     });
     expect(errors.length).to.eq(1);
     workspace.removeCallback();
-  }
+  });
 
-  @test
-  public async 'Create a new test case from a template on disk'(): Promise<void> {
+  it('Create a new test case from a template on disk', async () => {
     const { rootPath, program, cleanup } = await setupTestCase(
       path.join(TEST_CASES_FOLDER_PATH, SIMPLE_VARIABLES_TEST_CASE_NAME),
       ['src/index.ts'],
@@ -63,10 +58,9 @@ export class TestCaseCreation {
       .map(sf => sf.fileName);
     expect(relevantFiles).to.have.lengthOf(1);
     cleanup();
-  }
+  });
 
-  @test
-  public async 'Create a new test case from a template object'(): Promise<void> {
+  it('Create a new test case from a template object', async () => {
     const { rootPath, program, cleanup } = await setupTestCase(
       {
         'tsconfig.json': `{
@@ -112,24 +106,22 @@ export class TestCaseCreation {
       .map(sf => sf.fileName);
     expect(relevantFiles).to.have.lengthOf(1);
     cleanup();
-  }
+  });
 
-  @test
-  public async 'Test case actually exists on disk, and is a folder'(): Promise<void> {
+  it('Test case actually exists on disk, and is a folder', async () => {
     const { rootPath } = await createTempFixtureFolder(
       path.join(TEST_CASES_FOLDER_PATH, SIMPLE_VARIABLES_TEST_CASE_NAME),
     );
     expect(fs.existsSync(rootPath), 'exists').to.equal(true);
     expect(fs.statSync(rootPath).isDirectory(), 'is a directory').to.equal(true);
-  }
+  });
 
-  @test
-  public async 'Cleanup function removes test case from disk'(): Promise<void> {
+  it('Cleanup function removes test case from disk', async () => {
     const { rootPath, cleanup } = await createTempFixtureFolder(
       path.join(TEST_CASES_FOLDER_PATH, SIMPLE_VARIABLES_TEST_CASE_NAME),
     );
     expect(fs.existsSync(rootPath), 'exists').to.equal(true);
     cleanup();
     expect(fs.existsSync(rootPath), 'exists').to.equal(false);
-  }
-}
+  });
+});

--- a/packages/utils-node/package.json
+++ b/packages/utils-node/package.json
@@ -38,7 +38,6 @@
     "eslint-plugin-import": "2.16.0",
     "eslint-plugin-prettier": "3.0.1",
     "mocha": "5.2.0",
-    "mocha-typescript": "1.1.17",
     "nyc": "13.3.0",
     "remark-cli": "6.0.1",
     "remark-lint": "6.0.4",

--- a/packages/utils-node/test/mocha.opts
+++ b/packages/utils-node/test/mocha.opts
@@ -1,4 +1,3 @@
---ui mocha-typescript
 --require ts-node/register
 --require source-map-support/register
 --timeout 60000

--- a/packages/utils-node/test/node-host.test.ts
+++ b/packages/utils-node/test/node-host.test.ts
@@ -1,13 +1,11 @@
 import { expect } from 'chai';
 import { existsSync, mkdirSync, readFileSync, rmdirSync, unlinkSync } from 'fs';
-import { suite, test } from 'mocha-typescript';
+import { describe, it } from 'mocha';
 import { join } from 'path';
 import nodeHost from '../src/node-host';
 
-@suite
-export class NodeHostTests {
-  @test
-  public 'expected methods exist'(): void {
+describe('Node host tests', () => {
+  it('expected methods exist', () => {
     expect(Object.keys(nodeHost)).to.deep.eq([
       'readFileSync',
       'writeFileSync',
@@ -21,72 +19,72 @@ export class NodeHostTests {
       'removeFolderAndContents',
       'createTempFolder',
     ]);
-  }
+  });
 
-  @test public 'readFileSync tests'(): void {
+  it('readFileSync tests', () => {
     expect(nodeHost.readFileSync(join(__dirname, 'mocha.opts'))).contains('ts-node/register');
-  }
+  });
 
-  @test public 'writeFileSync tests'(): void {
+  it('writeFileSync tests', () => {
     const p = join(__dirname, 'foo.txt');
     nodeHost.writeFileSync(p, 'hello world');
     expect(readFileSync(p).toString()).to.eq('hello world');
     unlinkSync(p);
-  }
+  });
 
-  @test public 'fileOrFolderExists tests'(): void {
+  it('fileOrFolderExists tests', () => {
     expect(nodeHost.fileOrFolderExists(join(__dirname, '..'))).to.eq(true);
     expect(nodeHost.fileOrFolderExists(join(__dirname, '..', 'README.md'))).to.eq(true);
     expect(nodeHost.fileOrFolderExists(join(__dirname, '..', 'DO_NOT_README.md'))).to.eq(false);
-  }
+  });
 
-  @test public 'isFile tests'(): void {
+  it('isFile tests', () => {
     expect(nodeHost.isFile(join(__dirname, '..'))).to.eq(false);
     expect(nodeHost.isFile(join(__dirname, '..', 'README.md'))).to.eq(true);
-  }
+  });
 
-  @test public 'isFolder tests'(): void {
+  it('isFolder tests', () => {
     expect(nodeHost.isFolder(join(__dirname, '..'))).to.eq(true);
     expect(nodeHost.isFolder(join(__dirname, '..', 'README.md'))).to.eq(false);
-  }
+  });
 
-  @test public 'pathRelativeTo tests'(): void {
+  it('pathRelativeTo tests', () => {
     expect(
       nodeHost.pathRelativeTo(__dirname, join(__dirname, '..', 'README.md')).replace(/[\\/]+/g, ''),
     ).to.eq('..README.md');
-  }
+  });
 
-  @test public 'combinePaths tests'(): void {
+  it('combinePaths tests', () => {
     expect(nodeHost.combinePaths('foo/bar', 'baz').replace(/[\\/]+/g, '')).to.eq('foobarbaz');
     expect(nodeHost.combinePaths('foo/bar', 'baz', '..').replace(/[\\/]+/g, '')).to.eq('foobar');
-  }
+  });
 
-  @test public 'normalizePath tests'(): void {
+  it('normalizePath tests', () => {
     expect(nodeHost.normalizePath('foo/bar/./baz')).to.eq('foo/bar/baz');
-  }
+  });
 
-  @test public 'createFolder tests'(): void {
+  it('createFolder tests', () => {
     const p = join(__dirname, 'tempfolder');
     expect(existsSync(p)).to.eq(false);
     nodeHost.createFolder(p);
     expect(existsSync(p)).to.eq(true);
     rmdirSync(p);
-  }
+  });
 
-  @test public async 'removeFolderAndContents tests'(): Promise<void> {
+  it('removeFolderAndContents tests', async () => {
     const p = join(__dirname, 'tempfolder2');
     expect(existsSync(p)).to.eq(false);
     mkdirSync(p);
     expect(existsSync(p)).to.eq(true);
     await nodeHost.removeFolderAndContents(p);
     expect(existsSync(p)).to.eq(false);
-  }
+  });
 
-  @test public 'createTempFolder tests'(): void {
+  it('createTempFolder tests', () => {
     const { name, cleanup } = nodeHost.createTempFolder();
     expect(name).to.be.a('string');
     expect(existsSync(name)).to.eq(true);
     cleanup();
     expect(existsSync(name)).to.eq(false);
-  }
-}
+  });
+});

--- a/packages/utils-node/test/package-json.test.ts
+++ b/packages/utils-node/test/package-json.test.ts
@@ -1,38 +1,33 @@
 import { expect } from 'chai';
-import { suite, test } from 'mocha-typescript';
+import { describe, it } from 'mocha';
 import { join } from 'path';
 import { findPkgJson } from '../src/package-json';
 
-@suite
-export class PackageJsonUtilitiesTests {
-  @test
-  public async 'findPkgJson for a package within this monorepo'(): Promise<void> {
+describe('package.json utilities tests', () => {
+  it('findPkgJson for a package within this monorepo', async () => {
     const pkg = await findPkgJson(__dirname);
     if (!pkg) {
       throw new Error('could not find package.json info');
     }
     const knownPath = join(__dirname, '..');
     expect(pkg.path).to.eq(knownPath);
-  }
+  });
 
-  @test
-  public async 'findPkgJson the main monorepo'(): Promise<void> {
+  it('findPkgJson the main monorepo', async () => {
     const pkg = await findPkgJson(join(__dirname, '..', '..'));
     if (!pkg) {
       throw new Error('could not find package.json info');
     }
     const knownPath = join(__dirname, '..', '..', '..');
     expect(pkg.path).to.eq(knownPath);
-  }
+  });
 
-  @test
-  public async 'findPkgJson outside this project'(): Promise<void> {
+  it('findPkgJson outside this project', async () => {
     const pkg = await findPkgJson(join(__dirname, '..', '..', '..', '..'));
     expect(pkg).to.eq(undefined);
-  }
+  });
 
-  @test
-  public async 'attempting to pass invalid arguments'(): Promise<void> {
+  it('attempting to pass invalid arguments', async () => {
     try {
       await findPkgJson(null as any);
       expect(false).to.eq(true); // should never reach this
@@ -43,5 +38,5 @@ export class PackageJsonUtilitiesTests {
         expect(false).to.eq(true); // should never reach this
       }
     }
-  }
-}
+  });
+});

--- a/packages/utils-node/test/public-api-surface.test.ts
+++ b/packages/utils-node/test/public-api-surface.test.ts
@@ -1,30 +1,25 @@
 import { expect } from 'chai';
-import { suite, test } from 'mocha-typescript';
+import { describe, it } from 'mocha';
 import * as Exported from '../src/index';
 
-@suite
-export class PublicApiSurfaceTests {
-  @test
-  public 'NODE_HOST object exists'(): void {
+describe('Public API surface tests', () => {
+  it('NODE_HOST object exists', () => {
     expect(Exported.NODE_HOST).to.be.a('object');
-  }
+  });
 
-  @test
-  public 'createReverseResolverForProject exists'(): void {
+  it('createReverseResolverForProject exists', () => {
     expect(Exported.createReverseResolverForProject).to.be.a('function');
-  }
+  });
 
-  @test
-  public 'findPkgJson exists'(): void {
+  it('findPkgJson exists', () => {
     expect(Exported.findPkgJson).to.be.a('function');
-  }
+  });
 
-  @test
-  public 'no extra exports'(): void {
+  it('no extra exports', () => {
     expect(Object.keys(Exported).sort()).to.eql([
       'NODE_HOST',
       'createReverseResolverForProject',
       'findPkgJson',
     ]);
-  }
-}
+  });
+});

--- a/packages/utils-node/test/reverse-resolver.test.ts
+++ b/packages/utils-node/test/reverse-resolver.test.ts
@@ -1,30 +1,26 @@
 import { expect } from 'chai';
-import { suite, test } from 'mocha-typescript';
+import { describe, it } from 'mocha';
 import { join } from 'path';
 import NODE_HOST from '../src/node-host';
 import { createReverseResolverForProject } from '../src/reverse-resolver';
 
-@suite
-export class PathNormalizerTests {
-  @test
-  public async 'obtaining a non-passthrough normalizer'(): Promise<void> {
+describe('Module path normalizer tests', () => {
+  it('obtaining a non-passthrough normalizer', async () => {
     const normalizer = await createReverseResolverForProject(__dirname, NODE_HOST);
     expect(!!normalizer).to.eq(true);
     expect((normalizer as any).__passthroughNormalizer).to.eq(undefined);
-  }
+  });
 
-  @test
-  public async 'obtaining a passthrough normalizer'(): Promise<void> {
+  it('obtaining a passthrough normalizer', async () => {
     const normalizer = await createReverseResolverForProject(
       join(__dirname, '..', '..', '..', '..', '..'),
       NODE_HOST,
     );
     expect(!!normalizer).to.eq(true);
     expect((normalizer as any).__passthroughNormalizer).to.eq(true);
-  }
+  });
 
-  @test
-  public async 'accessing project root module through non-passthrough normalizer'(): Promise<void> {
+  it('accessing project root module through non-passthrough normalizer', async () => {
     const normalizer = await createReverseResolverForProject(__dirname, NODE_HOST);
     const normalizedData = normalizer.filePathToModuleInfo(
       join(__dirname, '..', 'src', 'index.ts'),
@@ -32,16 +28,13 @@ export class PathNormalizerTests {
     expect(normalizedData.relativePath).to.eq('src/index');
     expect(normalizedData.extension).to.eq('ts');
     expect(normalizedData.moduleName).to.eq('@code-to-json/utils-node');
-  }
+  });
 
-  @test
-  public async 'accessing project non-root module through non-passthrough normalizer'(): Promise<
-    void
-  > {
+  it('accessing project non-root module through non-passthrough normalizer', async () => {
     const normalizer = await createReverseResolverForProject(__dirname, NODE_HOST);
     const data = normalizer.filePathToModuleInfo(join(__dirname, '..', 'src', 'node-host.ts'));
     expect(data.relativePath).to.eq('src/node-host');
     expect(data.extension).to.eq('ts');
     expect(data.moduleName).to.eq('@code-to-json/utils-node/node-host');
-  }
-}
+  });
+});

--- a/packages/utils-ts/package.json
+++ b/packages/utils-ts/package.json
@@ -39,7 +39,6 @@
     "eslint-plugin-import": "2.16.0",
     "eslint-plugin-prettier": "3.0.1",
     "mocha": "5.2.0",
-    "mocha-typescript": "1.1.17",
     "nyc": "13.3.0",
     "remark-cli": "6.0.1",
     "remark-lint": "6.0.4",

--- a/packages/utils-ts/test/checks.test.ts
+++ b/packages/utils-ts/test/checks.test.ts
@@ -1,53 +1,46 @@
 import { expect } from 'chai';
-import { suite, test } from 'mocha-typescript';
+import { before, describe, it } from 'mocha';
 import * as ts from 'typescript';
 import { createProgramFromCodeString, isDeclarationExported, mapDict } from '../src/index';
 
-@suite('Checks tests')
-export class ChecksTests {
-  private sf!: ts.SourceFile;
+describe('Checks tests', () => {
+  let sf: ts.SourceFile;
 
-  private sfSym!: ts.Symbol;
+  let sfSym: ts.Symbol;
 
-  private checker!: ts.TypeChecker;
+  let checker: ts.TypeChecker;
 
-  public before(): void {
+  before(() => {
     const code = `export class Foo { bar: string; };
 let x: number = 4;
 function addToX(y: number): number { return x + y; }`;
     const out = createProgramFromCodeString(code, 'ts');
     const p = out.program;
-    const sf = p.getSourceFile('module.ts');
+    sf = p.getSourceFile('module.ts')!;
     if (!sf) {
       throw new Error('No source file module.ts found');
     }
-    this.sf = sf;
-    this.checker = p.getTypeChecker();
-    const sfSym = this.checker.getSymbolAtLocation(this.sf);
+    checker = p.getTypeChecker();
+    sfSym = checker.getSymbolAtLocation(sf)!;
     if (!sfSym) {
       throw new Error('SourceFile has no symbol');
     }
-    this.sfSym = sfSym;
-  }
+  });
 
-  @test
-  public isDeclarationExported(): void {
-    expect(isDeclarationExported(this.sf)).to.eql(
-      false,
-      'SourceFile is not an exported declaration',
-    );
-    const { exports } = this.sfSym;
+  it('isDeclarationExported tests', () => {
+    expect(isDeclarationExported(sf)).to.eql(false, 'SourceFile is not an exported declaration');
+    const { exports } = sfSym;
     if (!exports) {
       throw new Error('SourceFile has no exports');
     }
     if (!exports) {
       throw new Error('SourceFile has no exports');
     }
-    const allExports = mapDict(exports, (sym) => sym.declarations[0]);
+    const allExports = mapDict(exports, sym => sym.declarations[0]);
     expect(Object.keys(allExports).length).to.eql(1);
 
-    expect(this.sf.statements.length).to.eql(4);
-    expect(this.sf.statements[3].getText()).to.eql(
+    expect(sf.statements.length).to.eql(4);
+    expect(sf.statements[3].getText()).to.eql(
       'function addToX(y: number): number { return x + y; }',
     );
     const firstExport = allExports[Object.keys(allExports)[0]];
@@ -55,5 +48,5 @@ function addToX(y: number): number { return x + y; }`;
       throw new Error('Expected to find an export');
     }
     expect(isDeclarationExported(firstExport)).to.eq(true);
-  }
-}
+  });
+});

--- a/packages/utils-ts/test/compiler-host.test.ts
+++ b/packages/utils-ts/test/compiler-host.test.ts
@@ -1,13 +1,12 @@
 import { expect } from 'chai';
-import { suite, test } from 'mocha-typescript';
+import { describe, it } from 'mocha';
 import { join } from 'path';
 import { createProgram } from 'typescript';
 import CompilerHost from '../src/compiler-host';
 import { nodeHost } from './helpers';
 
-@suite
-export class CompilerHostTests {
-  @test public 'invalid attemot to obtain the name of a tslib'(): void {
+describe('Compiler host tests', () => {
+  it('invalid attemot to obtain the name of a tslib', () => {
     const ch = new CompilerHost(nodeHost);
     const prog = createProgram(
       [join(__dirname, '..', '..', '..', 'samples', 'ts-multi-file')],
@@ -15,5 +14,5 @@ export class CompilerHostTests {
       ch,
     );
     expect(prog.getSourceFiles().length).to.be.gt(0);
-  }
-}
+  });
+});

--- a/packages/utils-ts/test/declaration.test.ts
+++ b/packages/utils-ts/test/declaration.test.ts
@@ -1,16 +1,15 @@
 import { expect } from 'chai';
-import { suite, test } from 'mocha-typescript';
+import { describe, it } from 'mocha';
 import { isAbstractDeclaration } from '../src/declaration';
 import { filterDict } from '../src/dict';
 import { setupSingleModuleProgram } from './helpers';
 
-@suite
-export class DeclarationUtilTests {
-  @test public async 'invalid attemot to obtain the name of a tslib'(): Promise<void> {
+describe('Declaration utils tests', () => {
+  it('invalid attemot to obtain the name of a tslib', async () => {
     const t = await setupSingleModuleProgram(
       `export abstract class Foo { abstract bar(): string };`,
     );
-    const [file] = t.program.getSourceFiles().filter((f) => !f.isDeclarationFile);
+    const [file] = t.program.getSourceFiles().filter(f => !f.isDeclarationFile);
     expect(!!file).to.eq(true);
     const checker = t.program.getTypeChecker();
     const fileSym = checker.getSymbolAtLocation(file)!;
@@ -20,5 +19,5 @@ export class DeclarationUtilTests {
     );
     expect(isAbstractDeclaration(fooSym.valueDeclaration)).to.eq(true);
     t.cleanup();
-  }
-}
+  });
+});

--- a/packages/utils-ts/test/dict.test.ts
+++ b/packages/utils-ts/test/dict.test.ts
@@ -1,34 +1,33 @@
 import { Dict } from '@mike-north/types';
 import { expect } from 'chai';
-import { suite, test } from 'mocha-typescript';
+import { describe, it } from 'mocha';
 import { filterDict, forEachDict, mapDict, reduceDict } from '../src/dict';
 
-@suite
-export class DictUtilTests {
-  @test public async 'forEachDict - Dict<T>'(): Promise<void> {
+describe('Dict utilities tests', () => {
+  it('forEachDict - Dict<T>', async () => {
     const vals: string[] = [];
-    forEachDict({ foo: 'bar', biz: 'baz' } as Dict<string>, (s) => vals.push(s.toUpperCase()));
+    forEachDict({ foo: 'bar', biz: 'baz' } as Dict<string>, s => vals.push(s.toUpperCase()));
     expect(vals).to.deep.eq(['BAR', 'BAZ']);
-  }
+  });
 
-  @test public async 'mapDict - Dict<T>'(): Promise<void> {
-    expect(mapDict({ foo: 'bar', biz: 'baz' } as Dict<string>, (s) => s.toUpperCase())).to.deep.eq({
+  it('mapDict - Dict<T>', async () => {
+    expect(mapDict({ foo: 'bar', biz: 'baz' } as Dict<string>, s => s.toUpperCase())).to.deep.eq({
       foo: 'BAR',
       biz: 'BAZ',
     });
-  }
+  });
 
-  @test public async 'reduceDict - Dict<T>'(): Promise<void> {
+  it('reduceDict - Dict<T>', async () => {
     expect(reduceDict({ foo: 'bar', biz: 'baz' } as Dict<string>, (x, s) => x + s, '')).to.eq(
       'barbaz',
     );
-  }
+  });
 
-  @test public async 'filterDict - Dict<T>'(): Promise<void> {
+  it('filterDict - Dict<T>', async () => {
     expect(
-      filterDict({ foo: 'bar', biz: 'baz' } as Dict<string>, (s) => s[s.length - 1] === 'z'),
+      filterDict({ foo: 'bar', biz: 'baz' } as Dict<string>, s => s[s.length - 1] === 'z'),
     ).to.deep.eq({
       biz: 'baz',
     });
-  }
-}
+  });
+});

--- a/packages/utils-ts/test/flags.test.ts
+++ b/packages/utils-ts/test/flags.test.ts
@@ -1,13 +1,11 @@
 /* eslint-disable no-bitwise */
 import { expect } from 'chai';
-import { suite, test } from 'mocha-typescript';
+import { describe, it } from 'mocha';
 import * as ts from 'typescript';
 import { flagsToString } from '../src/flags';
 
-@suite
-export class FlagsTests {
-  @test
-  public async flagsToStringTests(): Promise<void> {
+describe('Flags tests', () => {
+  it('flagsToStringTests', async () => {
     expect(flagsToString(ts.ObjectFlags.Class, 'object')).to.deep.eq(['Class'], 'single flag');
     expect(flagsToString(ts.ObjectFlags.ClassOrInterface, 'object')).to.eql(
       ['Class', 'Interface'],
@@ -18,29 +16,29 @@ export class FlagsTests {
       undefined,
       'flag does not exist in map',
     );
-  }
+  });
 
-  @test public async 'type flags'(): Promise<void> {
+  it('type flags', async () => {
     expect(flagsToString(ts.TypeFlags.Intersection, 'type')).to.deep.equal(['Intersection']);
-  }
+  });
 
-  @test public async 'node flags'(): Promise<void> {
+  it('node flags', async () => {
     expect(flagsToString(ts.NodeFlags.AwaitContext, 'node')).to.deep.equal(['AwaitContext']);
-  }
+  });
 
-  @test public async 'nodeBuilder flags'(): Promise<void> {
+  it('nodeBuilder flags', async () => {
     expect(flagsToString(ts.NodeBuilderFlags.AllowEmptyTuple, 'nodeBuilder')).to.deep.eq([
       'AllowEmptyTuple',
     ]);
-  }
+  });
 
-  @test public async 'symbolFormat flags'(): Promise<void> {
+  it('symbolFormat flags', async () => {
     expect(
       flagsToString(ts.SymbolFormatFlags.UseAliasDefinedOutsideCurrentScope, 'symbolFormat'),
     ).to.deep.eq(['UseAliasDefinedOutsideCurrentScope']);
-  }
+  });
 
-  @test public async 'invalid flag type'(): Promise<void> {
+  it('invalid flag type', async () => {
     expect(() => flagsToString(33, 'xxx' as any)).to.throw('Unsupported flag type: xxx');
-  }
-}
+  });
+});

--- a/packages/utils-ts/test/generate-id.test.ts
+++ b/packages/utils-ts/test/generate-id.test.ts
@@ -1,33 +1,32 @@
 import { getDeclarationFiles } from '@code-to-json/test-helpers';
 import { expect } from 'chai';
-import { suite, test } from 'mocha-typescript';
+import { before, describe, it } from 'mocha';
 import * as ts from 'typescript';
 import { createIdGenerator, entityToString } from '../src/generate-id';
 import { createProgramFromCodeString, mapDict } from '../src/index';
 
-@suite
-export class GenerateIdTests {
-  private sourceFile!: ts.SourceFile;
+describe('ID generation tests', () => {
+  let sourceFile: ts.SourceFile;
 
-  private classDeclaration!: ts.Declaration;
+  let classDeclaration: ts.Declaration;
 
-  private varDeclaration!: ts.VariableDeclaration;
+  let varDeclaration: ts.VariableDeclaration;
 
-  private sourceFileSym!: ts.Symbol;
+  let sourceFileSym: ts.Symbol;
 
-  private sourceFileType!: ts.Type;
+  let sourceFileType: ts.Type;
 
-  private classSym!: ts.Symbol;
+  let classSym: ts.Symbol;
 
-  private classType!: ts.Type;
+  let classType: ts.Type;
 
-  private varSym!: ts.Symbol;
+  let varSym: ts.Symbol;
 
-  private checker!: ts.TypeChecker;
+  let checker: ts.TypeChecker;
 
-  private node!: ts.Node;
+  let node: ts.Node;
 
-  public before(): void {
+  before(() => {
     const { program } = createProgramFromCodeString(
       `
 export class Car {
@@ -41,86 +40,79 @@ export const x: string = 'foo';
       'ts',
     );
     const { nonDeclarationFiles } = getDeclarationFiles(program.getSourceFiles());
-    [this.sourceFile] = nonDeclarationFiles;
-    const checker = program.getTypeChecker();
+    [sourceFile] = nonDeclarationFiles;
+    checker = program.getTypeChecker();
 
-    const sym = checker.getSymbolAtLocation(this.sourceFile);
+    const sym = checker.getSymbolAtLocation(sourceFile);
     if (!sym) {
       throw new Error('no symbol for SourceFile');
     }
-    this.sourceFileSym = sym;
-    this.sourceFileType = checker.getTypeOfSymbolAtLocation(this.sourceFileSym, this.sourceFile);
+    sourceFileSym = sym;
+    sourceFileType = checker.getTypeOfSymbolAtLocation(sourceFileSym, sourceFile);
 
-    const { exports: fileExports } = this.sourceFileSym;
+    const { exports: fileExports } = sourceFileSym;
     if (!fileExports) {
       throw new Error('File has no exports');
     }
     const exportedSymbols: ts.Symbol[] = [];
-    const it = fileExports.values();
-    let itV = it.next();
-    while (!itV.done) {
-      exportedSymbols.push(itV.value);
-      itV = it.next();
+    const thing = fileExports.values();
+    let thingV = thing.next();
+    while (!thingV.done) {
+      exportedSymbols.push(thingV.value);
+      thingV = thing.next();
     }
     expect(exportedSymbols.length).to.eql(2);
-    [this.classSym, this.varSym] = exportedSymbols;
-    this.classType = checker.getDeclaredTypeOfSymbol(this.classSym);
-    expect(this.classSym.declarations.length).to.eql(1);
-    [this.classDeclaration] = this.classSym.declarations;
+    [classSym, varSym] = exportedSymbols;
+    classType = checker.getDeclaredTypeOfSymbol(classSym);
+    expect(classSym.declarations.length).to.eql(1);
+    [classDeclaration] = classSym.declarations;
 
-    expect(this.varSym.declarations.length).to.eql(1);
-    [this.varDeclaration] = this.varSym.declarations as ts.VariableDeclaration[];
-    this.checker = checker;
-    this.node = this.varDeclaration.initializer!.parent.getChildAt(4);
-  }
+    expect(varSym.declarations.length).to.eql(1);
+    [varDeclaration] = varSym.declarations as ts.VariableDeclaration[];
+    node = varDeclaration.initializer!.parent.getChildAt(4);
+  });
 
-  @test
-  public async 'generateId for sourceFile'(): Promise<void> {
-    const generateId = createIdGenerator(this.checker);
-    expect(generateId(this.sourceFile)).to.eql(['ok', 'F01m4wnf2ptes']);
-  }
+  it('generateId for sourceFile', async () => {
+    const generateId = createIdGenerator(checker);
+    expect(generateId(sourceFile)).to.eql(['ok', 'F01m4wnf2ptes']);
+  });
 
-  @test
-  public async 'generateId for symbol'(): Promise<void> {
-    const generateId = createIdGenerator(this.checker);
-    expect(generateId(this.sourceFileSym)[1])
+  it('generateId for symbol', async () => {
+    const generateId = createIdGenerator(checker);
+    expect(generateId(sourceFileSym)[1])
       .to.be.a('string')
       .and.to.have.lengthOf(13);
-  }
+  });
 
-  @test
-  public async 'generateId for type'(): Promise<void> {
-    const generateId = createIdGenerator(this.checker);
-    expect(generateId(this.classType)[1])
+  it('generateId for type', async () => {
+    const generateId = createIdGenerator(checker);
+    expect(generateId(classType)[1])
       .to.be.a('string')
       .and.to.have.length.greaterThan(0);
-  }
+  });
 
-  @test
-  public async 'generateId for class declaration'(): Promise<void> {
-    const generateId = createIdGenerator(this.checker);
-    expect(generateId(this.classDeclaration)[1])
+  it('generateId for class declaration', async () => {
+    const generateId = createIdGenerator(checker);
+    expect(generateId(classDeclaration)[1])
       .to.be.a('string')
       .and.to.have.lengthOf(13);
-  }
+  });
 
-  @test
-  public async 'generateId for variable declaration'(): Promise<void> {
-    const generateId = createIdGenerator(this.checker);
-    expect(generateId(this.varDeclaration)[1])
+  it('generateId for variable declaration', async () => {
+    const generateId = createIdGenerator(checker);
+    expect(generateId(varDeclaration)[1])
       .to.be.a('string')
       .and.to.have.lengthOf(13);
-  }
+  });
 
-  @test
-  public async 'generateId for class members and their children'(): Promise<void> {
-    const generateId = createIdGenerator(this.checker);
+  it('generateId for class members and their children', async () => {
+    const generateId = createIdGenerator(checker);
 
-    const { members } = this.classSym;
+    const { members } = classSym;
     if (!members) {
       throw new Error('No members in class');
     }
-    const memberSyms = mapDict(members, (s) => s);
+    const memberSyms = mapDict(members, s => s);
     const memberSym = memberSyms[Object.keys(memberSyms)[0]];
     if (!memberSym) {
       throw new Error('Expected to find at least one member symbol');
@@ -130,64 +122,59 @@ export const x: string = 'foo';
     expect(generateId(memberDecl)[1])
       .to.be.a('string')
       .and.to.have.lengthOf(13);
-    ts.forEachChild(memberDecl, (ch) => {
+    ts.forEachChild(memberDecl, ch => {
       expect(generateId(ch)[1])
         .to.be.a('string')
         .and.to.have.lengthOf(13);
     });
-  }
+  });
 
-  @test
-  public async 'generateId for null'(): Promise<void> {
-    const generateId = createIdGenerator(this.checker);
+  it('generateId for null', async () => {
+    const generateId = createIdGenerator(checker);
 
     expect(() => generateId(null as any)).to.throw('Cannot generate an ID for empty values');
-  }
+  });
 
-  @test
-  public async 'generateId for undefined'(): Promise<void> {
-    const generateId = createIdGenerator(this.checker);
+  it('generateId for undefined', async () => {
+    const generateId = createIdGenerator(checker);
 
     expect(() => generateId(undefined as any)).to.throw('Cannot generate an ID for empty values');
-  }
+  });
 
-  @test
-  public async 'generateId for 8'(): Promise<void> {
-    const generateId = createIdGenerator(this.checker);
+  it('generateId for 8', async () => {
+    const generateId = createIdGenerator(checker);
 
     expect(() => generateId(8 as any)).to.throw('Cannot generate an id for this object');
-  }
+  });
 
-  @test
-  public 'stable hashing'(): void {
-    const generateId = createIdGenerator(this.checker);
+  it('stable hashing', () => {
+    const generateId = createIdGenerator(checker);
 
-    expect(generateId(this.classDeclaration)).to.eql(['ok', 'D01m4wm4wrlxj'], 'class declaration');
-    expect(generateId(this.classSym)).to.eql(['ok', 'S01m4wntwmh9a'], 'class symbol');
-    expect(generateId(this.classType)).to.eql(['ok', 'T01m4wlnjqf0g'], 'class type');
-    expect(generateId(this.sourceFile)).to.eql(['ok', 'F01m4wnf2ptes'], 'source file');
-    expect(generateId(this.sourceFileSym)).to.eql(['ok', 'S01m4wnj0ln0d'], 'source file symbol');
-    expect(generateId(this.sourceFileType)).to.eql(['ok', 'T01m4wmnuc0f2'], 'source file type');
+    expect(generateId(classDeclaration)).to.eql(['ok', 'D01m4wm4wrlxj'], 'class declaration');
+    expect(generateId(classSym)).to.eql(['ok', 'S01m4wntwmh9a'], 'class symbol');
+    expect(generateId(classType)).to.eql(['ok', 'T01m4wlnjqf0g'], 'class type');
+    expect(generateId(sourceFile)).to.eql(['ok', 'F01m4wnf2ptes'], 'source file');
+    expect(generateId(sourceFileSym)).to.eql(['ok', 'S01m4wnj0ln0d'], 'source file symbol');
+    expect(generateId(sourceFileType)).to.eql(['ok', 'T01m4wmnuc0f2'], 'source file type');
 
-    expect(generateId(this.varSym)).to.eql(['ok', 'S01m4wmqaygbn'], 'variable symbol');
-    expect(generateId(this.varDeclaration)).to.eql(['ok', 'D01m4wlurlp4f'], 'variable declaration');
-  }
+    expect(generateId(varSym)).to.eql(['ok', 'S01m4wmqaygbn'], 'variable symbol');
+    expect(generateId(varDeclaration)).to.eql(['ok', 'D01m4wlurlp4f'], 'variable declaration');
+  });
 
-  @test
-  public 'entity stringifying'(): void {
-    expect(entityToString(undefined, this.checker)).to.eq('undefined');
-    expect(entityToString('foo', this.checker)).to.eq('foo');
-    expect(entityToString(6, this.checker)).to.eq('6');
-    expect(entityToString(this.classSym, this.checker)).to.eq('Car');
-    expect(entityToString(this.classType, this.checker)).to.eq('Car');
-    expect(entityToString(this.sourceFile, this.checker)).to.eq('FILE: module.ts');
-    expect(entityToString(this.sourceFileType, this.checker)).to.eq('typeof import("module")');
-    expect(entityToString(this.node, this.checker)).to.eq("'foo'");
-    expect(entityToString(this.classDeclaration, this.checker)).to.eq(`export class Car {
+  it('entity stringifying', () => {
+    expect(entityToString(undefined, checker)).to.eq('undefined');
+    expect(entityToString('foo', checker)).to.eq('foo');
+    expect(entityToString(6, checker)).to.eq('6');
+    expect(entityToString(classSym, checker)).to.eq('Car');
+    expect(entityToString(classType, checker)).to.eq('Car');
+    expect(entityToString(sourceFile, checker)).to.eq('FILE: module.ts');
+    expect(entityToString(sourceFileType, checker)).to.eq('typeof import("module")');
+    expect(entityToString(node, checker)).to.eq("'foo'");
+    expect(entityToString(classDeclaration, checker)).to.eq(`export class Car {
   public wheels: number = 4;
   constructor() {
     console.log('We are driving');
   }
 }`);
-  }
-}
+  });
+});

--- a/packages/utils-ts/test/guards.test.ts
+++ b/packages/utils-ts/test/guards.test.ts
@@ -1,6 +1,6 @@
 import { Dict } from '@mike-north/types';
 import { expect } from 'chai';
-import { suite, test } from 'mocha-typescript';
+import { before, describe, it } from 'mocha';
 import * as ts from 'typescript';
 import {
   createProgramFromCodeString,
@@ -19,19 +19,18 @@ import {
   SymbolRelevantTypes,
 } from '../src/index';
 
-@suite
-export class GuardTests {
-  private sf!: ts.SourceFile;
+describe('Guard tests', () => {
+  let sf: ts.SourceFile;
 
-  private sfSym!: ts.Symbol;
+  let sfSym: ts.Symbol;
 
-  private sfType!: ts.Type;
+  let sfType: ts.Type;
 
-  private exports!: Dict<{ sym: ts.Symbol; typ: SymbolRelevantTypes }>;
+  let exports: Dict<{ sym: ts.Symbol; typ: SymbolRelevantTypes }>;
 
-  private checker!: ts.TypeChecker;
+  let checker: ts.TypeChecker;
 
-  public before(): void {
+  before(() => {
     const code = `export class Foo { bar: string; };
 export let x: number = 4;
 export let str: string = 'abc';
@@ -48,134 +47,115 @@ export const helloFn: { foo: () => string } = { foo: () => 'hello' };
 export function addToX(y: number): number { return x + y; }`;
     const out = createProgramFromCodeString(code, 'ts');
     const p = out.program;
-    const sf = p.getSourceFile('module.ts');
+    sf = p.getSourceFile('module.ts')!;
     if (!sf) {
       throw new Error('No source file module.ts found');
     }
-    this.sf = sf;
-    this.checker = p.getTypeChecker();
-    const sfSym = this.checker.getSymbolAtLocation(this.sf);
+    checker = p.getTypeChecker();
+    sfSym = checker.getSymbolAtLocation(sf)!;
     if (!sfSym) {
       throw new Error('SourceFile has no symbol');
     }
-    this.sfSym = sfSym;
-    const sfType = getRelevantTypesForSymbol(this.checker, sfSym)!.valueDeclarationType;
+    sfType = getRelevantTypesForSymbol(checker, sfSym)!.valueDeclarationType!;
     if (!sfType) {
       throw new Error('Source file type could not be obtained');
     }
-    this.sfType = sfType;
-    this.exports = mapDict(this.sfSym.exports!, exp => ({
+    exports = mapDict(sfSym.exports!, exp => ({
       sym: exp,
-      typ: getRelevantTypesForSymbol(this.checker, exp)!,
+      typ: getRelevantTypesForSymbol(checker, exp)!,
     }));
-  }
+  });
 
-  @test
-  public isDeclaration(): void {
-    expect(isDeclaration(this.sf)).to.eql(true, 'SourceFile is a declaration');
-  }
+  it('isDeclaration', () => {
+    expect(isDeclaration(sf)).to.eql(true, 'SourceFile is a declaration');
+  });
 
-  @test
-  public isNode(): void {
-    expect(isNode(this.sf)).to.eql(true, 'SourceFile is a node');
-  }
+  it('isNode', () => {
+    expect(isNode(sf)).to.eql(true, 'SourceFile is a node');
+  });
 
-  @test
-  public isSymbol(): void {
-    expect(isSymbol(this.sf)).to.eql(false, 'SourceFile is not a symbol');
+  it('isSymbol', () => {
+    expect(isSymbol(sf)).to.eql(false, 'SourceFile is not a symbol');
 
-    expect(isSymbol(this.sfSym)).to.eql(true, 'SourceFile symbol is a symbol');
-    const sfType = this.checker.getTypeOfSymbolAtLocation(this.sfSym, this.sf);
-    expect(isSymbol(sfType)).to.eql(false, 'SourceFile symbol type is not a symbol');
-  }
+    expect(isSymbol(sfSym)).to.eql(true, 'SourceFile symbol is a symbol');
+    const mySfType = checker.getTypeOfSymbolAtLocation(sfSym, sf);
+    expect(isSymbol(mySfType)).to.eql(false, 'SourceFile symbol type is not a symbol');
+  });
 
-  @test
-  public isType(): void {
-    expect(isType(this.sf)).to.eql(false, 'SourceFile is not a type');
+  it('isType', () => {
+    expect(isType(sf)).to.eql(false, 'SourceFile is not a type');
 
-    expect(isType(this.sfSym)).to.eql(false, 'SourceFile symbol is not a type');
-    const sfType = this.checker.getTypeOfSymbolAtLocation(this.sfSym, this.sf);
-    expect(isType(sfType)).to.eql(true, 'SourceFile symbol type is a type');
-  }
+    expect(isType(sfSym)).to.eql(false, 'SourceFile symbol is not a type');
+    const mySfType = checker.getTypeOfSymbolAtLocation(sfSym, sf);
+    expect(isType(mySfType)).to.eql(true, 'SourceFile symbol type is a type');
+  });
 
-  @test
-  public isObjectType(): void {
-    expect(isObjectType(this.exports.Foo!.typ.valueDeclarationType!)).to.eql(
+  it('isObjectType', () => {
+    expect(isObjectType(exports.Foo!.typ.valueDeclarationType!)).to.eql(
       true,
       'class is an object type',
     );
-    expect(isObjectType(this.exports.x!.typ.valueDeclarationType!)).to.eql(
+    expect(isObjectType(exports.x!.typ.valueDeclarationType!)).to.eql(
       false,
       'number is not an object type',
     );
-  }
+  });
 
-  @test
-  public isObjectReferenceType(): void {
-    expect(isObjectReferenceType(this.exports.myFoo!.typ.valueDeclarationType!)).to.eql(
+  it('isObjectReferenceType', () => {
+    expect(isObjectReferenceType(exports.myFoo!.typ.valueDeclarationType!)).to.eql(
       true,
       'Class instance type is a reference type',
     );
-    expect(isObjectReferenceType(this.sfType)).to.eql(
-      false,
-      'SourceFile type is not a reference type',
-    );
-  }
+    expect(isObjectReferenceType(sfType)).to.eql(false, 'SourceFile type is not a reference type');
+  });
 
-  @test
-  public isInterfaceType(): void {
-    expect(isInterfaceType(this.exports.myFoo!.typ.valueDeclarationType!)).to.eql(
+  it('isInterfaceType', () => {
+    expect(isInterfaceType(exports.myFoo!.typ.valueDeclarationType!)).to.eql(
       true,
       'Class instance type is a class/interface type',
     );
-    expect(isInterfaceType(this.exports.Foo!.typ.valueDeclarationType!)).to.eql(
+    expect(isInterfaceType(exports.Foo!.typ.valueDeclarationType!)).to.eql(
       false,
       'Class constructor type is not a class/interface type',
     );
-    expect(isInterfaceType(this.sfType)).to.eql(
-      false,
-      'SourceFile type is not a class/interface type',
-    );
-  }
+    expect(isInterfaceType(sfType)).to.eql(false, 'SourceFile type is not a class/interface type');
+  });
 
-  @test
-  public isAnonymousType(): void {
-    expect(isAnonymousType(this.exports.helloFn!.typ.valueDeclarationType!)).to.eql(
+  it('isAnonymousType', () => {
+    expect(isAnonymousType(exports.helloFn!.typ.valueDeclarationType!)).to.eql(
       true,
       'helloFn type is anonymous',
     );
-    expect(isAnonymousType(this.exports.myFoo!.typ.valueDeclarationType!)).to.eql(
+    expect(isAnonymousType(exports.myFoo!.typ.valueDeclarationType!)).to.eql(
       false,
       'Class instance type is not anonymous',
     );
-  }
+  });
 
-  @test
-  public isConditionalType(): void {
-    expect(isConditionalType(this.exports.CondTyp!.typ.symbolType!)).to.eql(
+  it('isConditionalType', () => {
+    expect(isConditionalType(exports.CondTyp!.typ.symbolType!)).to.eql(
       true,
       'CondTyp type is conditional',
     );
-    expect(isConditionalType(this.exports.helloFn!.typ.valueDeclarationType!)).to.eql(
+    expect(isConditionalType(exports.helloFn!.typ.valueDeclarationType!)).to.eql(
       false,
       'helloFn type is not conditional',
     );
-  }
+  });
 
-  @test
-  public isPrimitiveType(): void {
-    expect(isPrimitiveType(this.exports.x!.typ.valueDeclarationType!)).to.eql(
+  it('isPrimitiveType', () => {
+    expect(isPrimitiveType(exports.x!.typ.valueDeclarationType!)).to.eql(
       true,
       'number is a primitive type',
     );
-    expect(isPrimitiveType(this.exports.str!.typ.valueDeclarationType!)).to.eql(
+    expect(isPrimitiveType(exports.str!.typ.valueDeclarationType!)).to.eql(
       true,
       'string is a primitive type',
     );
-    expect(isPrimitiveType(this.exports.boolVal!.typ.valueDeclarationType!)).to.eql(
+    expect(isPrimitiveType(exports.boolVal!.typ.valueDeclarationType!)).to.eql(
       true,
       'boolean is a primitive type',
     );
-    expect(isPrimitiveType(this.sfType)).to.eql(false, 'SourceFile type is not primitive');
-  }
-}
+    expect(isPrimitiveType(sfType)).to.eql(false, 'SourceFile type is not primitive');
+  });
+});

--- a/packages/utils-ts/test/mocha.opts
+++ b/packages/utils-ts/test/mocha.opts
@@ -1,4 +1,3 @@
---ui mocha-typescript
 --require ts-node/register
 --require source-map-support/register
 --timeout 60000

--- a/packages/utils-ts/test/module-path-normalizer.test.ts
+++ b/packages/utils-ts/test/module-path-normalizer.test.ts
@@ -1,12 +1,10 @@
 import { expect } from 'chai';
-import { suite, test } from 'mocha-typescript';
+import { describe, it } from 'mocha';
 import { createReverseResolver } from '../src/index';
 import { nodeHost } from './helpers';
 
-@suite
-export class ModulePathNormalizerTests {
-  @test
-  public async 'no project folder or main'(): Promise<void> {
+describe('ModulePathNormalizer tests', () => {
+  it('no project folder or main', async () => {
     const mn = createReverseResolver(nodeHost);
     expect(mn.filePathToModuleInfo('foo/bar/baz.ts')).to.deep.eq({
       originalFileName: 'foo/bar/baz.ts',
@@ -42,10 +40,9 @@ export class ModulePathNormalizerTests {
       moduleName: 'bin/code-to-json',
       extension: null,
     });
-  }
+  });
 
-  @test
-  public async 'yes project folder, no main'(): Promise<void> {
+  it('yes project folder, no main', async () => {
     const mn = createReverseResolver(nodeHost, { path: 'foo/bar', name: 'biz' });
     expect(mn.filePathToModuleInfo('foo/bar/baz.ts')).to.deep.eq({
       originalFileName: 'foo/bar/baz.ts',
@@ -53,10 +50,9 @@ export class ModulePathNormalizerTests {
       moduleName: 'biz/baz',
       extension: 'ts',
     });
-  }
+  });
 
-  @test
-  public async 'yes project folder, yes main'(): Promise<void> {
+  it('yes project folder, yes main', async () => {
     const mn = createReverseResolver(nodeHost, {
       path: 'foo/bar',
       name: 'biz',
@@ -76,10 +72,9 @@ export class ModulePathNormalizerTests {
       moduleName: 'biz',
       extension: 'ts',
     });
-  }
+  });
 
-  @test
-  public async 'scoped packages'(): Promise<void> {
+  it('scoped packages', async () => {
     const mn = createReverseResolver(nodeHost, {
       path: 'foo/bar',
       name: '@code-to-json/cli',
@@ -99,5 +94,5 @@ export class ModulePathNormalizerTests {
       moduleName: '@code-to-json/cli',
       extension: 'ts',
     });
-  }
-}
+  });
+});

--- a/packages/utils-ts/test/program.test.ts
+++ b/packages/utils-ts/test/program.test.ts
@@ -1,7 +1,7 @@
 import { createTempFixtureFolder, TestCaseFolder } from '@code-to-json/test-helpers';
 import { expect } from 'chai';
 import { existsSync, statSync, unlinkSync, writeFileSync } from 'fs';
-import { suite, test } from 'mocha-typescript';
+import { describe, it } from 'mocha';
 import * as path from 'path';
 import * as ts from 'typescript';
 import { createProgramFromCodeString, createProgramFromTsConfig, SysHost } from '../src/index';
@@ -49,10 +49,8 @@ async function makeWorkspace(): Promise<TestCaseFolder> {
   return workspace;
 }
 
-@suite('String to TypeScript program tests')
-export class TranspileProgramTest {
-  @test
-  public 'simple valid ts program'(): void {
+describe('String to TypeScript program tests', () => {
+  it('simple valid ts program', () => {
     const code = `export let x: number = 4;
 
     export function addToX(y: number): number { return x + y; }`;
@@ -74,10 +72,9 @@ function addToX(y) { return exports.x + y; }
 exports.addToX = addToX;
 `,
     );
-  }
+  });
 
-  @test
-  public 'simple valid js program'(): void {
+  it('simple valid js program', () => {
     const code = `export let x = 4;
 
     export function addToX(y) { return x + y; }`;
@@ -100,10 +97,9 @@ function addToX(y) { return exports.x + y; }
 exports.addToX = addToX;
 `,
     );
-  }
+  });
 
-  @test
-  public 'simple valid jsx program'(): void {
+  it('simple valid jsx program', () => {
     const code = `export let x = <span>4</span>;`;
     const out = createProgramFromCodeString(code, 'js', { jsx: ts.JsxEmit.React });
     const sourceFileNames = out.program.getSourceFiles().map(sf => sf.fileName);
@@ -122,10 +118,9 @@ Object.defineProperty(exports, "__esModule", { value: true });
 exports.x = React.createElement("span", null, "4");
 `,
     );
-  }
+  });
 
-  @test
-  public 'simple valid tsx program'(): void {
+  it('simple valid tsx program', () => {
     const code = `export const x = <span>4</span>;`;
     const out = createProgramFromCodeString(code, 'ts', { jsx: ts.JsxEmit.React });
     const sourceFileNames = out.program.getSourceFiles().map(sf => sf.fileName);
@@ -144,10 +139,9 @@ Object.defineProperty(exports, "__esModule", { value: true });
 exports.x = React.createElement("span", null, "4");
 `,
     );
-  }
+  });
 
-  @test
-  public 'simple invalid ts program'(): void {
+  it('simple invalid ts program', () => {
     const code = `export let x: number = 4;
     x = false;`;
     const out = createProgramFromCodeString(code, 'ts');
@@ -176,10 +170,9 @@ exports.x = 4;
 exports.x = false;
 `,
     );
-  }
+  });
 
-  @test
-  public 'simple invalid js program'(): void {
+  it('simple invalid js program', () => {
     const code = `export let x: number = 4;
     x = false;`;
     const out = createProgramFromCodeString(code, 'js');
@@ -217,10 +210,9 @@ exports.x = 4;
 exports.x = false;
 `,
     );
-  }
+  });
 
-  @test
-  public 'simple invalid jsx program'(): void {
+  it('simple invalid jsx program', () => {
     const code = `export let x = <span>4;
     x = false;`;
     const out = createProgramFromCodeString(code, 'js', { jsx: ts.JsxEmit.React });
@@ -249,10 +241,9 @@ exports.x = false;
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.x = React.createElement("span", null, "4; x = false;");
 `);
-  }
+  });
 
-  @test
-  public 'simple invalid tsx program'(): void {
+  it('simple invalid tsx program', () => {
     const code = `export let x = <div>4;
     x = false;`;
     const out = createProgramFromCodeString(code, 'ts', { jsx: ts.JsxEmit.React });
@@ -281,10 +272,9 @@ exports.x = React.createElement("span", null, "4; x = false;");
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.x = React.createElement("div", null, "4; x = false;");
 `);
-  }
+  });
 
-  @test
-  public async 'createProgramFromTsConfig - simple case'(): Promise<void> {
+  it('createProgramFromTsConfig - simple case', async () => {
     const workspace = await makeWorkspace();
 
     const prog = await createProgramFromTsConfig(workspace.rootPath, ...TEST_FILE_UTILS);
@@ -292,10 +282,9 @@ exports.x = React.createElement("div", null, "4; x = false;");
     expect(prog.getSourceFiles().filter(sf => !sf.isDeclarationFile).length).to.eql(3);
     expect(prog.getSourceFiles().length).to.be.greaterThan(3);
     workspace.cleanup();
-  }
+  });
 
-  @test
-  public async 'createProgramFromTsConfig - missing config'(): Promise<void> {
+  it('createProgramFromTsConfig - missing config', async () => {
     const workspace = await makeWorkspace();
     unlinkSync(path.join(workspace.rootPath, 'tsconfig.json'));
 
@@ -307,10 +296,9 @@ exports.x = React.createElement("div", null, "4; x = false;");
         expect(err.message).to.contain('Could not find a tsconfig.json via path');
       });
     workspace.cleanup();
-  }
+  });
 
-  @test
-  public async 'createProgramFromTsConfig - invalid config (non-json)'(): Promise<void> {
+  it('createProgramFromTsConfig - invalid config (non-json)', async () => {
     const workspace = await makeWorkspace();
     writeFileSync(path.join(workspace.rootPath, 'tsconfig.json'), '---');
 
@@ -322,10 +310,9 @@ exports.x = React.createElement("div", null, "4; x = false;");
         expect(err.message).to.contain('TSConfig error');
       });
     workspace.cleanup();
-  }
+  });
 
-  @test
-  public async 'createProgramFromTsConfig - invalid config (invalid schema)'(): Promise<void> {
+  it('createProgramFromTsConfig - invalid config (invalid schema)', async () => {
     const workspace = await makeWorkspace();
     writeFileSync(
       path.join(workspace.rootPath, 'tsconfig.json'),
@@ -342,10 +329,9 @@ exports.x = React.createElement("div", null, "4; x = false;");
         expect(err.message).to.contain('Detected errors while parsing tsconfig file');
       });
     workspace.cleanup();
-  }
+  });
 
-  @test
-  public async tsConfigForPathTests(): Promise<void> {
+  it('tsConfigForPathTests', async () => {
     const workspace = await makeWorkspace();
 
     const pth = ts.findConfigFile(path.join(workspace.rootPath), DEFAULT_FILE_EXISTENCE_CHECKER);
@@ -355,5 +341,5 @@ exports.x = React.createElement("div", null, "4; x = false;");
     expect(pth).to.contain('tsconfig.json');
     expect(existsSync(pth)).to.equal(true);
     workspace.cleanup();
-  }
-}
+  });
+});

--- a/packages/utils-ts/test/public-api-surface.test.ts
+++ b/packages/utils-ts/test/public-api-surface.test.ts
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import { suite, test } from 'mocha-typescript';
+import { describe, it } from 'mocha';
 import * as Exported from '../src/index';
 
 const {
@@ -39,11 +39,8 @@ const {
   modifiersToStrings,
   PASSTHROUGH_REVERSE_RESOLVER,
 } = Exported;
-
-@suite
-export class PublicApiSurface {
-  @test
-  public 'public API surface is as expected'(): void {
+describe('public API surface tests', () => {
+  it('public API surface is as expected', () => {
     expect(isDeclaration).to.be.a('function', 'isDeclaration is a function');
     expect(isDeclarationExported).to.be.a('function', 'isDeclarationExported is a function');
     expect(createProgramFromTsConfig).to.be.a(
@@ -94,10 +91,9 @@ export class PublicApiSurface {
       'object',
       'PASSTHROUGH_REVERSE_RESOLVER is a object',
     );
-  }
+  });
 
-  @test
-  public 'no extra exports'(): void {
+  it('no extra exports', () => {
     expect(Object.keys(Exported).sort()).to.eql([
       'PASSTHROUGH_REVERSE_RESOLVER',
       'createIdGenerator',
@@ -136,5 +132,5 @@ export class PublicApiSurface {
       'modifiersToStrings',
       'reduceDict',
     ]);
-  }
-}
+  });
+});

--- a/packages/utils-ts/test/relevant-types-for-symbol.test.ts
+++ b/packages/utils-ts/test/relevant-types-for-symbol.test.ts
@@ -1,15 +1,14 @@
 import { Dict } from '@mike-north/types';
 import { expect } from 'chai';
-import { suite, test } from 'mocha-typescript';
+import { before, describe, it } from 'mocha';
 import { SymbolRelevantTypes } from 'symbol';
 import * as ts from 'typescript';
 import { mapDict } from '../src/dict';
 import { createProgramFromCodeString } from '../src/program';
 import { getRelevantTypesForSymbol } from '../src/symbol';
 
-@suite
-export class RelevantTypesForSymbolTests {
-  public static before(): void {
+describe('RelevantTypesForSymbol Tests', () => {
+  before(() => {
     const code = `
 // Symbol Value checker get type of symbol value declaration
 const TextType = "Text";
@@ -56,57 +55,48 @@ export { Foo, ElementType, TextType, NodeType, DefaultType };
 `;
     const out = createProgramFromCodeString(code, 'ts');
     const p = out.program;
-    const sf = p.getSourceFile('module.ts');
+    sf = p.getSourceFile('module.ts')!;
     if (!sf) {
       throw new Error('No source file module.ts found');
     }
-    this.sf = sf;
-    this.checker = p.getTypeChecker();
-    const sfSym = this.checker.getSymbolAtLocation(this.sf);
+    checker = p.getTypeChecker();
+    sfSym = checker.getSymbolAtLocation(sf)!;
     if (!sfSym) {
       throw new Error('SourceFile has no symbol');
     }
-    this.exports = mapDict(sfSym.exports!, (exp) => ({
+    exports = mapDict(sfSym.exports!, exp => ({
       sym: exp,
       type: getRelevantTypesForSymbol(out.program.getTypeChecker(), exp),
     }));
-  }
-  private static sf: ts.SourceFile;
+  });
+  let sf: ts.SourceFile;
 
-  private static checker: ts.TypeChecker;
+  let sfSym: ts.Symbol;
 
-  private static exports: Dict<{ sym: ts.Symbol; type?: SymbolRelevantTypes }>;
+  let checker: ts.TypeChecker;
 
-  @test
-  public 'symbols are truthy'(): void {
-    const {
-      exports: { ElementType, TextType, NodeType, DefaultType, Foo },
-    } = RelevantTypesForSymbolTests;
+  let exports: Dict<{ sym: ts.Symbol; type?: SymbolRelevantTypes }>;
+
+  it('symbols are truthy', () => {
+    const { ElementType, TextType, NodeType, DefaultType, Foo } = exports;
     expect(!!ElementType!.sym).to.eql(true);
     expect(!!TextType!.sym).to.eql(true);
     expect(!!NodeType!.sym).to.eql(true);
     expect(!!Foo!.sym).to.eql(true);
     expect(!!DefaultType!.sym).to.eql(true);
-  }
+  });
 
-  @test
-  public 'types are truthy'(): void {
-    const {
-      exports: { ElementType, TextType, NodeType, DefaultType, Foo },
-    } = RelevantTypesForSymbolTests;
+  it('types are truthy', () => {
+    const { ElementType, TextType, NodeType, DefaultType, Foo } = exports;
     expect(!!ElementType!.type).to.eql(true);
     expect(!!TextType!.type).to.eql(true);
     expect(!!NodeType!.type).to.eql(true);
     expect(!!Foo!.type).to.eql(true);
     expect(!!DefaultType!.type).to.eql(true);
-  }
+  });
 
-  @test
-  public 'DefaultTypes type'(): void {
-    const {
-      checker,
-      exports: { DefaultType },
-    } = RelevantTypesForSymbolTests;
+  it('DefaultTypes type', () => {
+    const { DefaultType } = exports;
     expect(!!DefaultType!.type!.symbolType).to.eq(false, 'symbol type');
     expect(!!DefaultType!.type!.valueDeclarationType).to.eq(false, 'value declaration');
     expect(!!DefaultType!.type!.otherDeclarationTypes).to.eq(true, 'another declaration');
@@ -115,14 +105,10 @@ export { Foo, ElementType, TextType, NodeType, DefaultType };
       'NodeType',
       'typeToString - first declaration',
     );
-  }
+  });
 
-  @test
-  public 'NodeTypes type'(): void {
-    const {
-      checker,
-      exports: { NodeType },
-    } = RelevantTypesForSymbolTests;
+  it('NodeTypes type', () => {
+    const { NodeType } = exports;
     expect(!!NodeType!.type!.symbolType).to.eq(true, 'symbol type');
     expect(!!NodeType!.type!.valueDeclarationType).to.eq(false, 'value declaration');
     expect(!!NodeType!.type!.otherDeclarationTypes).to.eq(true, 'another declaration');
@@ -130,14 +116,10 @@ export { Foo, ElementType, TextType, NodeType, DefaultType };
       'NodeType',
       'typeToString - symbol type',
     );
-  }
+  });
 
-  @test
-  public 'TextTypes type'(): void {
-    const {
-      checker,
-      exports: { TextType },
-    } = RelevantTypesForSymbolTests;
+  it('TextTypes type', () => {
+    const { TextType } = exports;
     expect(!!TextType!.type!.symbolType).to.eq(true, 'symbol type');
     expect(!!TextType!.type!.valueDeclarationType).to.eq(false, 'value declaration');
     expect(!!TextType!.type!.otherDeclarationTypes).to.eq(true, 'another declaration');
@@ -147,14 +129,10 @@ export { Foo, ElementType, TextType, NodeType, DefaultType };
     );
     const [[a, atype]] = TextType!.type!.otherDeclarationTypes!;
     expect(checker.typeToString(atype!)).to.eq('"Text"', `typeToSTring - ${a}`);
-  }
+  });
 
-  @test
-  public 'ElementTypes type'(): void {
-    const {
-      checker,
-      exports: { ElementType },
-    } = RelevantTypesForSymbolTests;
+  it('ElementTypes type', () => {
+    const { ElementType } = exports;
     expect(!!ElementType!.type!.symbolType).to.eq(true, 'symbol type');
     expect(!!ElementType!.type!.valueDeclarationType).to.eq(false, 'value declaration');
     expect(!!ElementType!.type!.otherDeclarationTypes).to.eq(true, 'another declaration');
@@ -164,14 +142,10 @@ export { Foo, ElementType, TextType, NodeType, DefaultType };
     );
     const [[a, atype]] = ElementType!.type!.otherDeclarationTypes!;
     expect(checker.typeToString(atype!)).to.eq('"Element"', `typeToSTring - ${a}`);
-  }
+  });
 
-  @test
-  public 'Foos type'(): void {
-    const {
-      checker,
-      exports: { Foo },
-    } = RelevantTypesForSymbolTests;
+  it('Foos type', () => {
+    const { Foo } = exports;
     const { symbolType, otherDeclarationTypes, valueDeclarationType } = Foo!.type!;
     expect(!!symbolType).to.eq(true, 'symbol type');
     expect(!!valueDeclarationType).to.eq(false, 'value declaration');
@@ -182,9 +156,9 @@ export { Foo, ElementType, TextType, NodeType, DefaultType };
     expect(checker.typeToString(atype!)).to.eq('typeof Foo', `typeToSTring - ${a.getText()}`);
 
     expect(atype!.getProperties().length).to.eq(2);
-    expect(atype!.getProperties().map((p) => p.name)).to.include.deep.members(['biz']);
+    expect(atype!.getProperties().map(p => p.name)).to.include.deep.members(['biz']);
 
     expect(symbolType!.getProperties().length).to.eq(2);
-    expect(symbolType!.getProperties().map((p) => p.name)).to.deep.eq(['baz', 'bar']);
-  }
-}
+    expect(symbolType!.getProperties().map(p => p.name)).to.deep.eq(['baz', 'bar']);
+  });
+});

--- a/packages/utils-ts/test/symbol.test.ts
+++ b/packages/utils-ts/test/symbol.test.ts
@@ -1,6 +1,6 @@
 import { Dict } from '@mike-north/types';
 import { expect } from 'chai';
-import { suite, test } from 'mocha-typescript';
+import { before, describe, it } from 'mocha';
 import * as ts from 'typescript';
 import { mapDict } from '../src/dict';
 import { createProgramFromCodeString } from '../src/program';
@@ -10,17 +10,16 @@ import {
   SymbolRelevantTypes,
 } from '../src/symbol';
 
-@suite
-export class SymbolUtilityTests {
-  private sf!: ts.SourceFile;
+describe('Symbol utility tests', () => {
+  let sf: ts.SourceFile;
 
-  private sfSym!: ts.Symbol;
+  let sfSym: ts.Symbol;
 
-  private exports!: Dict<{ sym: ts.Symbol; typ: SymbolRelevantTypes; typStr: string }>;
+  let exports: Dict<{ sym: ts.Symbol; typ: SymbolRelevantTypes; typStr: string }>;
 
-  private checker!: ts.TypeChecker;
+  let checker: ts.TypeChecker;
 
-  public before(): void {
+  before(() => {
     const code = `export class Foo { bar: string; };
 export let x: number = 4;
 export let str: string = 'abc';
@@ -51,102 +50,83 @@ export const favSuit = Suit.Heart;
 `;
     const out = createProgramFromCodeString(code, 'ts');
     const p = out.program;
-    const sf = p.getSourceFile('module.ts');
+    sf = p.getSourceFile('module.ts')!;
     if (!sf) {
       throw new Error('No source file module.ts found');
     }
-    this.sf = sf;
-    this.checker = p.getTypeChecker();
-    const sfSym = this.checker.getSymbolAtLocation(this.sf);
+    checker = p.getTypeChecker();
+    sfSym = checker.getSymbolAtLocation(sf)!;
     if (!sfSym) {
       throw new Error('SourceFile has no symbol');
     }
-    this.sfSym = sfSym;
 
-    this.exports = mapDict(this.sfSym.exports!, (exp) => {
-      const typ = getRelevantTypesForSymbol(this.checker, exp)!;
+    exports = mapDict(sfSym.exports!, exp => {
+      const typ = getRelevantTypesForSymbol(checker, exp)!;
       return {
         sym: exp,
         typ,
-        typStr: getTypeStringForRelevantTypes(this.checker, typ),
+        typStr: getTypeStringForRelevantTypes(checker, typ),
       };
     });
-  }
+  });
 
-  @test
-  public 'relevantTypeForSymbol - simple variable'(): void {
-    expect(this.exports.x!.typStr).to.eql('number');
-  }
+  it('relevantTypeForSymbol - simple variable', () => {
+    expect(exports.x!.typStr).to.eql('number');
+  });
 
-  @test
-  public 'relevantTypeForSymbol - class'(): void {
-    expect(this.checker.typeToString(this.exports.Foo!.typ.valueDeclarationType!)).to.eql(
-      'typeof Foo',
-    );
-    expect(this.checker.typeToString(this.exports.Foo!.typ.symbolType!)).to.eql('Foo');
-    expect(this.exports.Foo!.typStr).to.eql('Foo\ntypeof Foo');
-  }
+  it('relevantTypeForSymbol - class', () => {
+    expect(checker.typeToString(exports.Foo!.typ.valueDeclarationType!)).to.eql('typeof Foo');
+    expect(checker.typeToString(exports.Foo!.typ.symbolType!)).to.eql('Foo');
+    expect(exports.Foo!.typStr).to.eql('Foo\ntypeof Foo');
+  });
 
-  @test
-  public 'relevantTypeForSymbol - anonymous structured type'(): void {
-    expect(this.exports.helloFn!.typStr).to.eql('{ foo: () => string; }');
-  }
+  it('relevantTypeForSymbol - anonymous structured type', () => {
+    expect(exports.helloFn!.typStr).to.eql('{ foo: () => string; }');
+  });
 
-  @test
-  public 'relevantTypeForSymbol - interface'(): void {
-    expect(this.exports.CondTyp!.typStr).to.eql('CondTyp<T>');
-  }
+  it('relevantTypeForSymbol - interface', () => {
+    expect(exports.CondTyp!.typStr).to.eql('CondTyp<T>');
+  });
 
-  @test
-  public 'relevantTypeForSymbol - function'(): void {
-    expect(this.exports.addToX!.typStr).to.eql('(y: number) => number');
-  }
+  it('relevantTypeForSymbol - function', () => {
+    expect(exports.addToX!.typStr).to.eql('(y: number) => number');
+  });
 
-  @test
-  public 'relevantTypeForSymbol - type query'(): void {
-    expect(this.exports.myTypeQuery!.typStr).to.eql('{ fn: (y: number) => number; }');
-  }
+  it('relevantTypeForSymbol - type query', () => {
+    expect(exports.myTypeQuery!.typStr).to.eql('{ fn: (y: number) => number; }');
+  });
 
-  @test
-  public 'relevantTypeForSymbol - type alias'(): void {
-    expect(this.exports.CondTyp!.typStr).to.eql('CondTyp<T>');
-  }
+  it('relevantTypeForSymbol - type alias', () => {
+    expect(exports.CondTyp!.typStr).to.eql('CondTyp<T>');
+  });
 
-  @test.skip
-  public 'relevantTypeForSymbol - type parameter'(): void {
-    const dictType = this.exports.Dict!.typ.symbolType! as ts.InterfaceType;
+  it.skip('relevantTypeForSymbol - type parameter', () => {
+    const dictType = exports.Dict!.typ.symbolType! as ts.InterfaceType;
     const { typeParameters } = dictType;
     if (!typeParameters) {
       throw new Error('undefined typeParameters');
     }
     const typeParam = typeParameters.values().next().value;
     const typeParamSym = typeParam.symbol;
-    expect(this.checker.typeToString(typeParam)).to.eql('T');
+    expect(checker.typeToString(typeParam)).to.eql('T');
     expect(
-      this.checker.typeToString(getRelevantTypesForSymbol(this.checker, typeParamSym)!.symbolType!),
+      checker.typeToString(getRelevantTypesForSymbol(checker, typeParamSym)!.symbolType!),
     ).to.eql('T');
-  }
+  });
 
-  @test
-  public 'relevantTypeForSymbol - enum collection'(): void {
-    expect(this.checker.typeToString(this.exports.Suit!.typ.valueDeclarationType!)).to.eql(
-      'typeof Suit',
-    );
-    expect(this.checker.typeToString(this.exports.Suit!.typ.symbolType!)).to.eql('Suit');
-  }
+  it('relevantTypeForSymbol - enum collection', () => {
+    expect(checker.typeToString(exports.Suit!.typ.valueDeclarationType!)).to.eql('typeof Suit');
+    expect(checker.typeToString(exports.Suit!.typ.symbolType!)).to.eql('Suit');
+  });
 
-  @test
-  public 'relevantTypeForSymbol - mapped type'(): void {
-    expect(this.exports.MyMapped!.typStr).to.eql('MyMapped<K>');
-  }
+  it('relevantTypeForSymbol - mapped type', () => {
+    expect(exports.MyMapped!.typStr).to.eql('MyMapped<K>');
+  });
 
-  @test
-  public 'relevantTypeForSymbol - enum member'(): void {
-    expect(this.exports.favSuit!.typStr).to.eql('Suit.Heart');
-    expect(!!this.exports.favSuit!.typ.symbolType).to.eq(false);
-    expect(!!this.exports.favSuit!.typ.valueDeclarationType).to.eq(true);
-    expect(this.checker.typeToString(this.exports.favSuit!.typ.valueDeclarationType!)).to.eq(
-      'Suit.Heart',
-    );
-  }
-}
+  it('relevantTypeForSymbol - enum member', () => {
+    expect(exports.favSuit!.typStr).to.eql('Suit.Heart');
+    expect(!!exports.favSuit!.typ.symbolType).to.eq(false);
+    expect(!!exports.favSuit!.typ.valueDeclarationType).to.eq(true);
+    expect(checker.typeToString(exports.favSuit!.typ.valueDeclarationType!)).to.eq('Suit.Heart');
+  });
+});

--- a/packages/utils-ts/test/ts-lib.test.ts
+++ b/packages/utils-ts/test/ts-lib.test.ts
@@ -1,16 +1,15 @@
 import { expect } from 'chai';
-import { suite, test } from 'mocha-typescript';
+import { describe, it } from 'mocha';
 import { getTsLibName } from '../src/ts-lib';
 
-@suite
-export class TsLibsTests {
-  @test public 'invalid attemot to obtain the name of a tslib'(): void {
+describe('TSLib tests', () => {
+  it('invalid attemot to obtain the name of a tslib', () => {
     expect(getTsLibName('/Users/mike/foo/bar/index.ts')).to.eq(undefined);
-  }
+  });
 
-  @test public 'valid attemot to obtain the name of a tslib'(): void {
+  it('valid attemot to obtain the name of a tslib', () => {
     expect(getTsLibName('/Users/mike/foo/bar/node_modules/typescript/lib/lib.es5.d.ts')).to.eq(
       'lib.es5.d.ts',
     );
-  }
-}
+  });
+});

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -34,7 +34,6 @@
     "eslint-plugin-import": "2.16.0",
     "eslint-plugin-prettier": "3.0.1",
     "mocha": "5.2.0",
-    "mocha-typescript": "1.1.17",
     "nyc": "13.3.0",
     "remark-cli": "6.0.1",
     "remark-lint": "6.0.4",

--- a/packages/utils/test/array.test.ts
+++ b/packages/utils/test/array.test.ts
@@ -1,11 +1,9 @@
 import { expect } from 'chai';
-import { suite, test } from 'mocha-typescript';
+import { describe, it } from 'mocha';
 import { all, isArray, isHomogenousArray, some } from '../src/array';
 
-@suite
-export class ArrayUtilsTests {
-  @test
-  public 'isArray tests'(): void {
+describe('Array utilities tests', () => {
+  it('isArray tests', () => {
     expect(isArray(0 as any)).to.eql(false, 'number');
     expect(isArray(null as any)).to.eql(false, 'null');
     expect(isArray(undefined as any)).to.eql(false, 'undefined');
@@ -15,10 +13,9 @@ export class ArrayUtilsTests {
     expect(isArray(() => '')).to.eql(false, 'function');
     expect(isArray(class A {})).to.eql(false, 'class');
     expect(isArray(new class B {}() as any)).to.eql(false, 'instance');
-  }
+  });
 
-  @test
-  public 'isHomogenousArray tests'(): void {
+  it('isHomogenousArray tests', () => {
     expect(isHomogenousArray([1, '2'], v => typeof v === 'string')).to.eql(false, 'mixed contents');
     expect(isHomogenousArray([1, 2, 3], v => typeof v === 'number')).to.eql(
       true,
@@ -26,20 +23,18 @@ export class ArrayUtilsTests {
     );
     expect(isHomogenousArray([], v => typeof v === 'string')).to.eql(true, 'empty case');
     expect(isHomogenousArray([[1], ['2']], isArray)).to.eql(true, 'nested array case');
-  }
+  });
 
-  @test
-  public 'some tests'(): void {
+  it('some tests', () => {
     expect(some([1, '2'], v => typeof v === 'string')).to.deep.eq(true);
     expect(some([1, '2'], v => typeof v === 'function')).to.deep.eq(false);
     expect(some([1, 2], v => typeof v === 'number')).to.deep.eq(true);
-  }
+  });
 
-  @test
-  public 'all tests'(): void {
+  it('all tests', () => {
     expect(all([1, '2'], v => typeof v === 'string')).to.deep.eq(false);
     expect(all([1, '2'], v => typeof v === 'function')).to.deep.eq(false);
     expect(all([1, 2], v => typeof v === 'number')).to.deep.eq(true);
     expect(all([], v => typeof v === 'number')).to.deep.eq(true);
-  }
-}
+  });
+});

--- a/packages/utils/test/checks.test.ts
+++ b/packages/utils/test/checks.test.ts
@@ -1,11 +1,9 @@
 import { expect } from 'chai';
-import { suite, test } from 'mocha-typescript';
+import { describe, it } from 'mocha';
 import { isDefined, isNotNull } from '../src/checks';
 
-@suite('Simple predicates')
-export class SimpleChecks {
-  @test
-  public 'isNotNull tests'(): void {
+describe('Simple predicates', () => {
+  it('isNotNull tests', () => {
     expect(isNotNull(0)).to.eql(true);
     expect(isNotNull(null)).to.eql(false);
     expect(isNotNull(undefined)).to.eql(true);
@@ -16,10 +14,9 @@ export class SimpleChecks {
     expect(isNotNull({ length: 33 })).to.eql(true);
     expect(isNotNull((): string => 'foo')).to.eql(true);
     expect(isNotNull(new Map([['a', 1]]))).to.eql(true);
-  }
+  });
 
-  @test
-  public 'isDefined tests'(): void {
+  it('isDefined tests', () => {
     expect(isDefined(0)).to.eql(true);
     expect(isDefined(null)).to.eql(true);
     expect(isDefined(undefined)).to.eql(false);
@@ -30,5 +27,5 @@ export class SimpleChecks {
     expect(isDefined({ length: 33 })).to.eql(true);
     expect(isDefined((): string => 'foo')).to.eql(true);
     expect(isDefined(new Map([['a', 1]]))).to.eql(true);
-  }
-}
+  });
+});

--- a/packages/utils/test/deferred-processing.test.ts
+++ b/packages/utils/test/deferred-processing.test.ts
@@ -1,29 +1,25 @@
 import { expect } from 'chai';
-import { suite, test } from 'mocha-typescript';
+import { beforeEach, describe, it } from 'mocha';
 import { createQueue, Queue } from '../src/index';
 
-@suite
-export class DeferredProcessingTests {
-  public q!: Queue<'foo', { idd: string }, any>;
-
-  public before(): void {
-    this.q = createQueue<{ foo: any }, 'foo', { idd: string }>(
+describe('Deferred processing tests', () => {
+  let q: Queue<'foo', { idd: string }, any>;
+  beforeEach(() => {
+    q = createQueue<{ foo: any }, 'foo', { idd: string }>(
       'foo',
       (val: { idd: string }) => `~~${val.idd}~~`,
     );
-  }
+  });
 
-  @test
-  public '.queue returns a ref'(): void {
-    const ref = this.q.queue({ idd: '12345' });
+  it('.queue returns a ref', () => {
+    const ref = q.queue({ idd: '12345' });
     expect(ref).to.deep.eq(['foo', '~~12345~~']);
-  }
+  });
 
-  @test
-  public '.drain calls back w/ the original object'(): void {
-    this.q.queue({ idd: '23456' });
+  it('.drain calls back w/ the original object', () => {
+    q.queue({ idd: '23456' });
     let iterationCount = 0;
-    this.q.drain((ref, item) => {
+    q.drain((ref, item) => {
       expect(ref).to.deep.eq(['foo', '~~23456~~']);
       expect(item).to.deep.eq({
         idd: '23456',
@@ -31,20 +27,18 @@ export class DeferredProcessingTests {
       iterationCount++;
     });
     expect(iterationCount).to.eq(1);
-  }
+  });
 
-  @test
-  public '.drain returns the processed object count'(): void {
-    this.q.queue({ idd: 'asdklh' });
-    const { processedCount } = this.q.drain((_ref, _item) => '');
+  it('.drain returns the processed object count', () => {
+    q.queue({ idd: 'asdklh' });
+    const { processedCount } = q.drain((_ref, _item) => '');
     expect(processedCount).to.eq(1);
-  }
+  });
 
-  @test
-  public '.drainUntilEmpty completely drains everything'(): void {
-    this.q.queue({ idd: '23456' });
+  it('.drainUntilEmpty completely drains everything', () => {
+    q.queue({ idd: '23456' });
     let icount = 0;
-    this.q.drainUntilEmpty((reff, item) => {
+    q.drainUntilEmpty((reff, item) => {
       expect(reff).to.deep.eq(['foo', '~~23456~~']);
       expect(item).to.deep.eq({
         idd: '23456',
@@ -52,15 +46,14 @@ export class DeferredProcessingTests {
       icount++;
     });
     expect(icount).to.eq(1);
-  }
+  });
 
-  @test
-  public '.queue de-duplicates repeated queues'(): void {
+  it('.queue de-duplicates repeated queues', () => {
     const obj = { idd: '34567' };
-    this.q.queue(obj);
-    this.q.queue(obj);
+    q.queue(obj);
+    q.queue(obj);
     let iterationCount = 0;
-    this.q.drain((r, item) => {
+    q.drain((r, item) => {
       expect(r).to.deep.eq(['foo', '~~34567~~']);
       expect(item).to.deep.eq({
         idd: '34567',
@@ -68,5 +61,5 @@ export class DeferredProcessingTests {
       iterationCount++;
     });
     expect(iterationCount).to.eq(1);
-  }
-}
+  });
+});

--- a/packages/utils/test/error.test.ts
+++ b/packages/utils/test/error.test.ts
@@ -1,13 +1,11 @@
 import { expect } from 'chai';
-import { suite, test } from 'mocha-typescript';
 import { UnreachableError } from '../src/index';
+import { describe, it } from 'mocha';
 
-@suite
-export class ErrorTests {
-  @test
-  public 'UnreachableError tests'(): void {
+describe('Error tests', () => {
+  it('UnreachableError tests', () => {
     expect(() => {
       throw new UnreachableError('' as never);
     }).to.throw('Reached code that should be unreachable');
-  }
-}
+  });
+});

--- a/packages/utils/test/error.test.ts
+++ b/packages/utils/test/error.test.ts
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
-import { UnreachableError } from '../src/index';
 import { describe, it } from 'mocha';
+import { UnreachableError } from '../src/index';
 
 describe('Error tests', () => {
   it('UnreachableError tests', () => {

--- a/packages/utils/test/mocha.opts
+++ b/packages/utils/test/mocha.opts
@@ -1,4 +1,3 @@
---ui mocha-typescript
 --require ts-node/register
 --require source-map-support/register
 --timeout 60000

--- a/packages/utils/test/pipe.test.ts
+++ b/packages/utils/test/pipe.test.ts
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import { suite, test } from 'mocha-typescript';
+import { describe, it } from 'mocha';
 import { pipe } from '../src/pipe';
 
 function square(x: number): number {
@@ -19,9 +19,8 @@ function digitSum(x: number): number {
   return s.split('').reduce((sum, y) => sum + parseInt(y, 10), 0);
 }
 
-@suite
-export class PipeTests {
-  @test public 'basic use'(): void {
+describe('Pipe tests', () => {
+  it('basic use', () => {
     expect(pipe()(3)).to.eql(3);
     expect(pipe(square)(3)).to.eql(9);
     expect(
@@ -54,5 +53,5 @@ export class PipeTests {
         digitSum,
       )(4),
     ).to.eql(12);
-  }
-}
+  });
+});

--- a/packages/utils/test/promise.test.ts
+++ b/packages/utils/test/promise.test.ts
@@ -1,11 +1,9 @@
 import { expect } from 'chai';
-import { suite, test } from 'mocha-typescript';
+import { describe, it } from 'mocha';
 import { timeout } from '../src/index';
 
-@suite
-export class PromiseTests {
-  @test
-  public async 'timeout tests'(): Promise<void> {
+describe('Promise tests', () => {
+  it('timeout tests', async () => {
     let resolved = false;
     const p = timeout(100).then(() => {
       resolved = true;
@@ -15,5 +13,5 @@ export class PromiseTests {
     expect(resolved).to.eq(false, 'short timeout resolves sooner than longer timeout (1)');
     await timeout(101);
     expect(resolved).to.eq(true, 'short timeout resolves sooner than longer timeout (2)');
-  }
-}
+  });
+});

--- a/packages/utils/test/ref.test.ts
+++ b/packages/utils/test/ref.test.ts
@@ -1,16 +1,14 @@
 import { expect } from 'chai';
-import { suite, test } from 'mocha-typescript';
+import { describe, it } from 'mocha';
 import { createRef } from '../src/deferred-processing/ref';
 import { isRef } from '../src/index';
 
-@suite
-export class RefTests {
-  @test
-  public 'isRef tests'(): void {
+describe('Ref tests', () => {
+  it('isRef tests', () => {
     expect(isRef([] as any)).to.eql(false);
     expect(isRef()).to.eql(false);
     const r = createRef<{ foo: string }, 'foo'>('foo', '1231');
     expect(isRef(r)).to.eql(true);
     expect(isRef(['foo' as any, 99 as any])).to.eql(false);
-  }
-}
+  });
+});

--- a/packages/utils/test/string.test.ts
+++ b/packages/utils/test/string.test.ts
@@ -1,15 +1,14 @@
 import { expect } from 'chai';
-import { suite, test } from 'mocha-typescript';
+import { describe, it } from 'mocha';
 import { camelize } from '../src/string';
 
-@suite
-export class StringUtilTests {
-  @test public 'camelize tests'(): void {
+describe('String utilities tests', () => {
+  it('camelize tests', () => {
     expect(camelize('')).to.eq('');
     expect(camelize('FooBar')).to.eq('fooBar');
     expect(camelize('Foo')).to.eq('foo');
     expect(camelize('Foo_bar')).to.eq('fooBar');
     expect(camelize('foo_bar')).to.eq('fooBar');
     expect(camelize('foo-bar')).to.eq('fooBar');
-  }
-}
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -980,11 +980,6 @@
   resolved "https://registry.yarnpkg.com/@types/mocha/-/mocha-5.2.6.tgz#b8622d50557dd155e9f2f634b7d68fd38de5e94b"
   integrity sha512-1axi39YdtBI7z957vdqXI4Ac25e7YihYQtJa+Clnxg1zTJEaIRbndt71O3sP4GAMgiAm0pY26/b9BrY4MR/PMw==
 
-"@types/mocha@^5.2.0":
-  version "5.2.5"
-  resolved "https://registry.yarnpkg.com/@types/mocha/-/mocha-5.2.5.tgz#8a4accfc403c124a0bafe8a9fc61a05ec1032073"
-  integrity sha512-lAVp+Kj54ui/vLUFxsJTMtWvZraZxum3w3Nwkble2dNuV5VnPA+Mi2oGX9XYJAaIvZi3tn3cbjS/qcJXRb6Bww==
-
 "@types/node@*":
   version "10.12.19"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.12.19.tgz#ca1018c26be01f07e66ac7fefbeb6407e4490c61"
@@ -2222,7 +2217,7 @@ decamelize-keys@^1.0.0:
     decamelize "^1.1.0"
     map-obj "^1.0.0"
 
-decamelize@^1.1.0, decamelize@^1.1.1, decamelize@^1.1.2, decamelize@^1.2.0:
+decamelize@^1.1.0, decamelize@^1.1.2, decamelize@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
   integrity sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=
@@ -3676,11 +3671,6 @@ into-stream@^3.1.0:
     from2 "^2.1.1"
     p-is-promise "^1.1.0"
 
-invert-kv@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/invert-kv/-/invert-kv-1.0.0.tgz#104a8e4aaca6d3d8cd157a8ef8bfab2d7a3ffdb6"
-  integrity sha1-EEqOSqym09jNFXqO+L+rLXo//bY=
-
 invert-kv@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/invert-kv/-/invert-kv-2.0.0.tgz#7393f5afa59ec9ff5f67a27620d11c226e3eec02"
@@ -4263,13 +4253,6 @@ latest-version@^3.0.0:
   dependencies:
     package-json "^4.0.0"
 
-lcid@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/lcid/-/lcid-1.0.0.tgz#308accafa0bc483a3867b4b6f2b9506251d1b835"
-  integrity sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=
-  dependencies:
-    invert-kv "^1.0.0"
-
 lcid@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/lcid/-/lcid-2.0.0.tgz#6ef5d2df60e52f82eb228a4c373e8d1f397253cf"
@@ -4608,13 +4591,6 @@ mdast-util-to-string@^1.0.2, mdast-util-to-string@^1.0.4:
   resolved "https://registry.yarnpkg.com/mdast-util-to-string/-/mdast-util-to-string-1.0.5.tgz#3552b05428af22ceda34f156afe62ec8e6d731ca"
   integrity sha512-2qLt/DEOo5F6nc2VFScQiHPzQ0XXcabquRJxKMhKte8nt42o08HUxNDPk7tt0YPxnWjAT11I1SYi0X0iPnfI5A==
 
-mem@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/mem/-/mem-1.1.0.tgz#5edd52b485ca1d900fe64895505399a0dfa45f76"
-  integrity sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=
-  dependencies:
-    mimic-fn "^1.0.0"
-
 mem@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/mem/-/mem-4.0.0.tgz#6437690d9471678f6cc83659c00cbafcd6b0cdaf"
@@ -4798,16 +4774,6 @@ mkdirp@0.5.1, "mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.0:
   integrity sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=
   dependencies:
     minimist "0.0.8"
-
-mocha-typescript@1.1.17:
-  version "1.1.17"
-  resolved "https://registry.yarnpkg.com/mocha-typescript/-/mocha-typescript-1.1.17.tgz#f78b29ad4f87fce8c25f657883e3eca39fb026c9"
-  integrity sha512-Ge6pCQkZumkkhxVNdAf3JxunskShgaynCb30HYD7TT1Yhog/7NW2+6w5RcRHI+nuQrCMTX6z1+qf2pD8qwCoQA==
-  dependencies:
-    "@types/mocha" "^5.2.0"
-    chalk "^2.4.1"
-    cross-spawn "^6.0.5"
-    yargs "^11.0.0"
 
 mocha@5.2.0:
   version "5.2.0"
@@ -5261,15 +5227,6 @@ os-homedir@^1.0.0, os-homedir@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/os-homedir/-/os-homedir-1.0.2.tgz#ffbc4988336e0e833de0c168c7ef152121aa7fb3"
   integrity sha1-/7xJiDNuDoM94MFox+8VISGqf7M=
-
-os-locale@^2.0.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/os-locale/-/os-locale-2.1.0.tgz#42bc2900a6b5b8bd17376c8e882b65afccf24bf2"
-  integrity sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==
-  dependencies:
-    execa "^0.7.0"
-    lcid "^1.0.0"
-    mem "^1.1.0"
 
 os-locale@^3.0.0:
   version "3.1.0"
@@ -8152,11 +8109,6 @@ xtend@^4.0.1, xtend@~4.0.1:
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.1.tgz#a5c6d532be656e23db820efb943a1f04998d63af"
   integrity sha1-pcbVMr5lbiPbgg77lDofBJmNY68=
 
-y18n@^3.2.1:
-  version "3.2.1"
-  resolved "https://registry.yarnpkg.com/y18n/-/y18n-3.2.1.tgz#6d15fba884c08679c0d77e88e7759e811e07fa41"
-  integrity sha1-bRX7qITAhnnA136I53WegR4H+kE=
-
 "y18n@^3.2.1 || ^4.0.0", y18n@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-4.0.0.tgz#95ef94f85ecc81d007c264e190a120f0a3c8566b"
@@ -8186,31 +8138,6 @@ yargs-parser@^11.1.1:
   dependencies:
     camelcase "^5.0.0"
     decamelize "^1.2.0"
-
-yargs-parser@^9.0.2:
-  version "9.0.2"
-  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-9.0.2.tgz#9ccf6a43460fe4ed40a9bb68f48d43b8a68cc077"
-  integrity sha1-nM9qQ0YP5O1Aqbto9I1DuKaMwHc=
-  dependencies:
-    camelcase "^4.1.0"
-
-yargs@^11.0.0:
-  version "11.1.0"
-  resolved "https://registry.yarnpkg.com/yargs/-/yargs-11.1.0.tgz#90b869934ed6e871115ea2ff58b03f4724ed2d77"
-  integrity sha512-NwW69J42EsCSanF8kyn5upxvjp5ds+t3+udGBeTbFnERA+lF541DDpMawzo4z6W/QrzNM18D+BPMiOBibnFV5A==
-  dependencies:
-    cliui "^4.0.0"
-    decamelize "^1.1.1"
-    find-up "^2.1.0"
-    get-caller-file "^1.0.1"
-    os-locale "^2.0.0"
-    require-directory "^2.1.1"
-    require-main-filename "^1.0.1"
-    set-blocking "^2.0.0"
-    string-width "^2.0.0"
-    which-module "^2.0.0"
-    y18n "^3.2.1"
-    yargs-parser "^9.0.2"
 
 yargs@^12.0.1, yargs@^12.0.5:
   version "12.0.5"


### PR DESCRIPTION
Mocha's typescript support out of the box is getting better all the time. At this point
there's not a lot of value in adding the `mocha-typescript` package -- in fact continuing to use it
may create barriers for new contributors.